### PR TITLE
Fix compatibility with Alloy 6

### DIFF
--- a/algorithms/discovery/INSLabel.als
+++ b/algorithms/discovery/INSLabel.als
@@ -53,8 +53,8 @@ sig AVTree extends LabelTree {
   Null !in (vnodes - root).label + anodes.label
   anodes.label in Attribute
   vnodes.label in Value
-  all n: nodes | all /* disj */ c,c': n.children |
-    c.label != c'.label
+  all n: nodes | all /* disj */ c,c": n.children |
+    c.label != c".label
   all a: anodes | a.children in vnodes && some a.children
   all v: vnodes | v.children in anodes
   no Wildcard.~label.children
@@ -80,8 +80,8 @@ one sig DB extends AVTree {
   all v: vnodes {
     no v.children => some v.recs
     no v.recs & v.^(~children).recs }
-  all a: anodes | all disj v,v': a.children |
-    (no v.*children.recs & v'.*children.recs)
+  all a: anodes | all disj v,v": a.children |
+    (no v.*children.recs & v".*children.recs)
 }
 
 one sig State {
@@ -95,8 +95,8 @@ fact ConformsFixPoint {
       q.ConformsAux[a,nq,na] <=>
       {
        nq.label in Wildcard + na.label
-       all nq': q.children[nq] | some na': a.children[na] |
-         q.ConformsAux[a,nq',na']
+       all nq": q.children[nq] | some na": a.children[na] |
+         q.ConformsAux[a,nq",na"]
       }
 }
 

--- a/algorithms/discovery/ins.als
+++ b/algorithms/discovery/ins.als
@@ -108,6 +108,6 @@ pred RemoveWildCard[me: Query, q: Query] {
 }
 
 assert MissingAttributeAsWildcard {
-  all db : DB, q, q' : Query, found: set Record |
-    db.Lookup[q, found] && q.RemoveWildCard[q'] => db.Lookup[q', found]
+  all db : DB, q, q" : Query, found: set Record |
+    db.Lookup[q, found] && q.RemoveWildCard[q"] => db.Lookup[q", found]
 }

--- a/algorithms/distributed-hashtable/chord.als
+++ b/algorithms/distributed-hashtable/chord.als
@@ -14,10 +14,10 @@ fact {all i: Id | Id in i.*next}
  * true iff i precedes j in the order starting at from
  */
 pred less_than [from, i,j: Id] {
-        let next' = Id<:next - (Id->from) | j in i.^next'  // if from=j, returns true if # nodes > 1
+        let next" = Id<:next - (Id->from) | j in i.^next"  // if from=j, returns true if # nodes > 1
         }
 pred less_than_eq [from, i,j: Id] {
-        let next' = Id<:next - (Id->from) | j in i.*next'
+        let next" = Id<:next - (Id->from) | j in i.*next"
         }
 
 sig Node {id: Id}
@@ -38,7 +38,7 @@ sig State {
         }
 
 /**
- * node n's next node is defined to be the m where n's finger table maps the id
+ * node n"s next node is defined to be the m where n"s finger table maps the id
  * that follows n.id to m
  * next holds the first entry of the finger table
  */
@@ -47,28 +47,28 @@ fact {all s: State | all n: s.active | n.(s.data).next = n.(s.data).finger[n.id.
 pred NextCorrect [s: State] {
         all n: s.active {
                 -- no intervening node (ie, close enough)
-                no n': s.active - n | less_than [n.id, n'.id, n.(s.data).next.id]
+                no n": s.active - n | less_than [n.id, n".id, n.(s.data).next.id]
                 -- can reach all other active nodes (ie, far enough)
-                -- need this because can't rule out case of next being node itself (because of 1-node ring)
+                -- need this because can"t rule out case of next being node itself (because of 1-node ring)
                 -- s.active in n.*(s.data.next)
                 n.(s.data).next != n || #s.active = 1
                 }
         }
 
-pred NextCorrect' [s: State] {
+pred NextCorrect" [s: State] {
 -- next seems to be correct for 1,2,3 nodes
         all n: s.active | let nd = (s.data)[n] {
-                let next' = Id<:next - (Id -> nd.next.id) {
-                        no n' : s.active { n'.id in n.id.^next' }
+                let next" = Id<:next - (Id -> nd.next.id) {
+                        no n" : s.active { n".id in n.id.^next" }
                 }}
         }
 
 // valid
-assert Same1 {all s: State | NextCorrect[s] => NextCorrect'[s]}
+assert Same1 {all s: State | NextCorrect[s] => NextCorrect"[s]}
 check Same1 for 3 but 1 State expect 0
 
 // valid unless active condition removed
-assert Same2 {all s: State | s.active = Node => (NextCorrect'[s] => NextCorrect[s])}
+assert Same2 {all s: State | s.active = Node => (NextCorrect"[s] => NextCorrect[s])}
 check Same2 for 3 but 1 State expect 0
 
 -- assert NextInFinger {all s: State | all n: s.active | some n.s.data.finger[n.id.next] }
@@ -79,23 +79,23 @@ check Same2 for 3 but 1 State expect 0
 pred FingersCorrect [s: State] {
         all nd: s.active.(s.data) | all start:nd.finger.univ |
                 nd.finger[start] in s.active &&
-                (no n' : s.active | less_than [start, n'.id, nd.finger[start].id])
+                (no n" : s.active | less_than [start, n".id, nd.finger[start].id])
         }
 
 
-pred FingersCorrect' [s: State] {
+pred FingersCorrect" [s: State] {
         all n: s.active | let nd = (s.data)[n] | all start: Node.~(nd.finger) {
                 nd.finger[start] in s.active &&
-                (let next' = Id<:next - (nd.finger[start].id -> Id) {
-                        no n' : s.active - nd.finger[start] {
-                                n'.id in start.*next'
+                (let next" = Id<:next - (nd.finger[start].id -> Id) {
+                        no n" : s.active - nd.finger[start] {
+                                n".id in start.*next"
                         }
                 })
             }
         }
 
 
-assert SameFC {all s: State | FingersCorrect [s] iff FingersCorrect'[s]}
+assert SameFC {all s: State | FingersCorrect [s] iff FingersCorrect"[s]}
 check SameFC for 3 but 1 State expect 0
 
 
@@ -108,7 +108,7 @@ run ShowMeFC for 2 but 1 State expect 1
 pred ClosestPrecedingFinger[s: State] {
         all n: s.active | let nd = n.(s.data) |
                 all i: Id | let cpf = nd.closest_preceding_finger[i] {
-                        no n': nd.finger[Id] + n - cpf | less_than [cpf.id, n'.id, i]
+                        no n": nd.finger[Id] + n - cpf | less_than [cpf.id, n".id, i]
                         cpf in nd.finger[Id] + n
                         cpf.id != i || # s.active = 1
                         //less_than (n.id, cpf.id, i)
@@ -116,26 +116,26 @@ pred ClosestPrecedingFinger[s: State] {
         }
 
 
-pred ClosestPrecedingFinger'[s: State] {
+pred ClosestPrecedingFinger"[s: State] {
         all n: s.active | let nd = (s.data)[n] | all i: Id {
-                let next' = Id<:next - (Id -> i) {
-                        nd.next.id in n.id.^next' =>
+                let next" = Id<:next - (Id -> i) {
+                        nd.next.id in n.id.^next" =>
                                 // nd.closest_preceding_finger[i] = nd.next,
                                 (some n1: nd.finger[Id] {
                                         nd.closest_preceding_finger[i] = n1
                                         //n1 in nd.finger[Id]
-                                        n1.id in n.id.^next'
-                                        no n2: nd.finger[Id] | n2.id in n1.id.^next'
+                                        n1.id in n.id.^next"
+                                        no n2: nd.finger[Id] | n2.id in n1.id.^next"
                                 }) else
                         nd.closest_preceding_finger[i] = n
                 }}
         }
 
 
-assert SameCPF {all s: State | FingersCorrect[s] => (ClosestPrecedingFinger [s] iff ClosestPrecedingFinger' [s])}
-assert SameCPF1 {all s: State | FingersCorrect[s] => (ClosestPrecedingFinger [s] => ClosestPrecedingFinger' [s])}
+assert SameCPF {all s: State | FingersCorrect[s] => (ClosestPrecedingFinger [s] iff ClosestPrecedingFinger" [s])}
+assert SameCPF1 {all s: State | FingersCorrect[s] => (ClosestPrecedingFinger [s] => ClosestPrecedingFinger" [s])}
 assert SameCPF2 {
-        all s: State | ((s.active = Node && FingersCorrect[s] && ClosestPrecedingFinger' [s])
+        all s: State | ((s.active = Node && FingersCorrect[s] && ClosestPrecedingFinger" [s])
          => ClosestPrecedingFinger [s]) }
 
 check SameCPF for 3 but 1 State expect 0
@@ -145,7 +145,7 @@ check SameCPF2 for 3 but 1 State expect 0
 
 pred ShowMeCPF {
         all s : State | s.active = Node && FingersCorrect[s] &&
-        // not ClosestPrecedingFinger(s) && ClosestPrecedingFinger'(s)
+        // not ClosestPrecedingFinger(s) && ClosestPrecedingFinger"(s)
         ClosestPrecedingFinger[s]
         //all s : State | all nd : s.active.s.data | nd.finger[Id] = Node
         # Node = 2
@@ -172,10 +172,10 @@ assert FPisActive {
 check FPisActive for 3 but 1 State expect 1
 
 
-pred FindPredecessor'[s: State] {
+pred FindPredecessor"[s: State] {
         all n: s.active | let nd = (s.data)[n] | all i: Id {
-                let next' = Id<:next - (nd.next.id -> Id) {
-                        one s.active or i in n.id.^next' =>  // *next' -> ^next' 1/8/02
+                let next" = Id<:next - (nd.next.id -> Id) {
+                        one s.active or i in n.id.^next" =>  // *next" -> ^next" 1/8/02
                         nd.find_predecessor[i] = n else
                         nd.find_predecessor[i] =
                         ((s.data)[nd.closest_preceding_finger[i]]).find_predecessor[i]
@@ -184,14 +184,14 @@ pred FindPredecessor'[s: State] {
 
 
 assert SameFP {all s: State | FingersCorrect[s] // && s.active = Node
-        => (FindPredecessor [s] iff FindPredecessor' [s])}
+        => (FindPredecessor [s] iff FindPredecessor" [s])}
 
 assert SameFP1 {
         all s: State | FingersCorrect[s] && s.active = Node
-                => (FindPredecessor [s] => FindPredecessor' [s])}
+                => (FindPredecessor [s] => FindPredecessor" [s])}
 assert SameFP2 {
         all s: State | FingersCorrect[s] && s.active = Node
-                => (FindPredecessor' [s] => FindPredecessor [s])}
+                => (FindPredecessor" [s] => FindPredecessor [s])}
 
 check SameFP for 3 but 1 State expect 1
 check SameFP1 for 3 but 1 State expect 0
@@ -253,6 +253,6 @@ assert FindSuccessorWorks {
                 let nd = s.active.(s.data) |
                 let succ = nd.find_successor [i] |
                         FingersCorrect [s] // && s.active = Node
-                                => (no n': s.active | less_than [i, n'.id, succ.id])
+                                => (no n": s.active | less_than [i, n".id, succ.id])
         }
 check FindSuccessorWorks for 3 but 1 State expect 1

--- a/algorithms/distributed-hashtable/chord2.als
+++ b/algorithms/distributed-hashtable/chord2.als
@@ -15,10 +15,10 @@ fact {all i: Id | Id in i.*next}
  * true iff i precedes j in the order starting at from
  */
 pred less_than [from, i,j: Id] {
-  let next' = Id<:next - (Id->from) | j in i.^next'  // if from=j, returns true if # nodes > 1
+  let next" = Id<:next - (Id->from) | j in i.^next"  // if from=j, returns true if # nodes > 1
   }
 pred less_than_eq [from, i,j: Id] {
-  let next' = Id<:next - (Id->from) | j in i.*next'
+  let next" = Id<:next - (Id->from) | j in i.*next"
   }
 
 sig Node {id: Id}
@@ -38,7 +38,7 @@ sig State {
   }
 
 /**
- * node n's next node is defined to be the m where n's finger table maps the id
+ * node n"s next node is defined to be the m where n"s finger table maps the id
  * that follows n.id to m
  * next holds the first entry of the finger table
  */
@@ -47,9 +47,9 @@ fact {all s: State | all n: s.active | n.(s.data).next = n.(s.data).finger[n.id.
 pred NextCorrect [s: State] {
   all n: s.active {
     -- no intervening node (ie, close enough)
-    no n': s.active - n | less_than [n.id, n'.id, n.(s.data).next.id]
+    no n": s.active - n | less_than [n.id, n".id, n.(s.data).next.id]
     -- can reach all other active nodes (ie, far enough)
-    -- need this because can't rule out case of next being node itself (because of 1-node ring)
+    -- need this because can"t rule out case of next being node itself (because of 1-node ring)
     -- s.active in n.*(s.data.next)
     n.(s.data).next != n || #s.active = 1
     }
@@ -65,17 +65,17 @@ fun NextCorrect" (s: State) {
   }
 */
 
-pred NextCorrect' [s: State] {
+pred NextCorrect" [s: State] {
 -- next seems to be correct for 1,2,3 nodes
   all n: s.active | let nd = (s.data)[n] {
-    let next' = Id<:next - (Id -> nd.next.id) {
-      no n' : s.active { n'.id in n.id.^next' }
+    let next" = Id<:next - (Id -> nd.next.id) {
+      no n" : s.active { n".id in n.id.^next" }
     }}
   }
 
-assert Same1 {all s: State | NextCorrect[s] => NextCorrect'[s]}
+assert Same1 {all s: State | NextCorrect[s] => NextCorrect"[s]}
 //check Same1 for 3 but 1 State -- valid
-assert Same2 {all s: State | s.active = Node => (NextCorrect'[s] => NextCorrect[s])}
+assert Same2 {all s: State | s.active = Node => (NextCorrect"[s] => NextCorrect[s])}
 //check Same2 for 3 but 1 State -- invalid if active condition removed
 
 -- assert NextInFinger {all s: State | all n: s.active | some n.s.data.finger[n.id.next] }
@@ -87,19 +87,19 @@ assert Same2 {all s: State | s.active = Node => (NextCorrect'[s] => NextCorrect[
 pred FingersCorrect [s: State] {
   all nd: s.active.(s.data) | all start:nd.finger.univ |
     nd.finger[start] in s.active &&
-    (no n' : s.active | less_than [start, n'.id, nd.finger[start].id])
+    (no n" : s.active | less_than [start, n".id, nd.finger[start].id])
   }
 
-pred FingersCorrect' [s: State] {
+pred FingersCorrect" [s: State] {
   all n: s.active | let nd = (s.data)[n] | all start: Node.~(nd.finger) {
     nd.finger[start] in s.active &&
-    (let next' = Id<:next - (nd.finger[start].id -> Id) {
-      no n' : s.active - nd.finger[start] {
-        n'.id in start.*next'
+    (let next" = Id<:next - (nd.finger[start].id -> Id) {
+      no n" : s.active - nd.finger[start] {
+        n".id in start.*next"
     }})}
   }
 
-assert SameFC {all s: State | FingersCorrect [s] iff FingersCorrect'[s]}
+assert SameFC {all s: State | FingersCorrect [s] iff FingersCorrect"[s]}
 //check SameFC for 3 but 1 State
 
 pred ShowMeFC {
@@ -112,7 +112,7 @@ pred ShowMeFC {
 fun ClosestPrecedingFinger(s: State) {
   all n: s.active | let nd = n.s.data |
     all i: Id | let cpf = nd.closest_preceding_finger[i] {
-      no n': nd.finger[Id] | less_than (cpf.id, n'.id, i)
+      no n": nd.finger[Id] | less_than (cpf.id, n".id, i)
       cpf in nd.finger[Id] + n
       less_than (n.id, cpf.id, i)
     }
@@ -122,7 +122,7 @@ fun ClosestPrecedingFinger(s: State) {
 pred ClosestPrecedingFinger_SAVE [s: State] {
   all n: s.active | let nd = n.(s.data) |
     all i: Id | let cpf = nd.closest_preceding_finger[i] {
-      no n': (nd.finger[Id] + n) - cpf | less_than [cpf.id, n'.id, i]
+      no n": (nd.finger[Id] + n) - cpf | less_than [cpf.id, n".id, i]
       cpf in nd.finger[Id] + n
       cpf.id != i || # s.active = 1
       //less_than (n.id, cpf.id, i)
@@ -130,7 +130,7 @@ pred ClosestPrecedingFinger_SAVE [s: State] {
   }
 
 pred CPFBody [s: State, n: Node, nd: NodeData, i: Id, cpf: Node] {
-  no n': (nd.finger[Id] + n) - cpf | less_than [cpf.id, n'.id, i]
+  no n": (nd.finger[Id] + n) - cpf | less_than [cpf.id, n".id, i]
   cpf in nd.finger[Id] + n
   cpf.id != i || # s.active = 1
   }
@@ -140,25 +140,25 @@ pred ClosestPrecedingFinger[s: State] {
     some cpf: Node | CPFBody [s,n,nd,i,cpf] => CPFBody [s,n,nd,i,nd.closest_preceding_finger[i]]
   }
 
-pred ClosestPrecedingFinger'[s: State] {
+pred ClosestPrecedingFinger"[s: State] {
   all n: s.active | let nd = (s.data)[n] | all i: Id {
-    let next' = Id<:next - (Id -> i) {
-      nd.next.id in n.id.^next' =>
+    let next" = Id<:next - (Id -> i) {
+      nd.next.id in n.id.^next" =>
         // nd.closest_preceding_finger[i] = nd.next,
         (some n1: nd.finger[Id] {
           nd.closest_preceding_finger[i] = n1
           //n1 in nd.finger[Id]
-          n1.id in n.id.^next'
-          no n2: nd.finger[Id] | n2.id in n1.id.^next'
+          n1.id in n.id.^next"
+          no n2: nd.finger[Id] | n2.id in n1.id.^next"
         }) else
       nd.closest_preceding_finger[i] = n
     }}
   }
 
-assert SameCPF {all s: State | FingersCorrect[s] => (ClosestPrecedingFinger [s] iff ClosestPrecedingFinger' [s])}
-assert SameCPF1 {all s: State | FingersCorrect[s] => (ClosestPrecedingFinger [s] => ClosestPrecedingFinger' [s])}
+assert SameCPF {all s: State | FingersCorrect[s] => (ClosestPrecedingFinger [s] iff ClosestPrecedingFinger" [s])}
+assert SameCPF1 {all s: State | FingersCorrect[s] => (ClosestPrecedingFinger [s] => ClosestPrecedingFinger" [s])}
 assert SameCPF2 {
-  all s: State | ((s.active = Node && FingersCorrect[s] && ClosestPrecedingFinger' [s])
+  all s: State | ((s.active = Node && FingersCorrect[s] && ClosestPrecedingFinger" [s])
    => ClosestPrecedingFinger [s]) }
 //check SameCPF for 3 but 1 State
 //check SameCPF1 for 2 but 1 State
@@ -166,7 +166,7 @@ assert SameCPF2 {
 
 pred ShowMeCPF  {
   all s : State | s.active = Node && FingersCorrect[s] &&
-        // not ClosestPrecedingFinger(s) && ClosestPrecedingFinger'(s)
+        // not ClosestPrecedingFinger(s) && ClosestPrecedingFinger"(s)
         ClosestPrecedingFinger[s]
   //all s : State | all nd : s.active.s.data | nd.finger[Id] = Node
   # Node = 2
@@ -183,7 +183,7 @@ pred FindPredecessor[s: State] {
       else (nd.closest_preceding_finger[i].(s.data).find_predecessor)[i])
     }
   }
--- problem : could return node that's inactive ???
+-- problem : could return node that"s inactive ???
 
 assert FPisActive {
   all s: State | FingersCorrect[s] && ClosestPrecedingFinger[s] && FindPredecessor[s]
@@ -192,10 +192,10 @@ assert FPisActive {
 
 //check FPisActive for 3 but 1 State
 
-pred FindPredecessor'[s: State] {
+pred FindPredecessor"[s: State] {
   all n: s.active | let nd = (s.data)[n] | all i: Id {
-    let next' = Id<:next - (nd.next.id -> Id) {
-      one s.active or i in n.id.^next' =>
+    let next" = Id<:next - (nd.next.id -> Id) {
+      one s.active or i in n.id.^next" =>
       nd.find_predecessor[i] = n else
       nd.find_predecessor[i] =
       ((s.data)[nd.closest_preceding_finger[i]]).find_predecessor[i]
@@ -203,13 +203,13 @@ pred FindPredecessor'[s: State] {
   }
 
 assert SameFP {all s: State | FingersCorrect[s] && s.active = Node
-  => (FindPredecessor [s] iff FindPredecessor' [s])}
+  => (FindPredecessor [s] iff FindPredecessor" [s])}
 assert SameFP1 {
   all s: State | FingersCorrect[s] && s.active = Node
-    => (FindPredecessor [s] => FindPredecessor' [s])}
+    => (FindPredecessor [s] => FindPredecessor" [s])}
 assert SameFP2 {
   all s: State | FingersCorrect[s] && s.active = Node
-    => (FindPredecessor' [s] => FindPredecessor [s])}
+    => (FindPredecessor" [s] => FindPredecessor [s])}
 //check SameFP for 3 but 1 State
 //check SameFP1 for 3 but 1 State
 //check SameFP2 for 3 but 1 State
@@ -265,7 +265,7 @@ assert FindSuccessorWorks {
     let succ = nd.find_successor [i] |
       FingersCorrect [s]
       => {
-        no n': s.active | less_than [i, n'.id, succ.id]
+        no n": s.active | less_than [i, n".id, succ.id]
         succ in s.active
         }
   }

--- a/algorithms/distributed-hashtable/chordbugmodel.als
+++ b/algorithms/distributed-hashtable/chordbugmodel.als
@@ -10,11 +10,11 @@ sig Id {next: Id}
 fact {all i: Id | Id in i.*next}
 
 pred less_than [from, i,j: Id] {
-   let next' = Id<:next - (Id->from) | j in i.^next'
+   let next" = Id<:next - (Id->from) | j in i.^next"
 }
 
 pred less_than_eq [from, i,j: Id] {
-   let next' = Id<:next - (Id->from) | j in i.*next'
+   let next" = Id<:next - (Id->from) | j in i.*next"
 }
 
 sig Node {id: Id}
@@ -39,7 +39,7 @@ fact {
 
 pred NextCorrect [s: State] {
    all n: s.active | let succ = n.(s.data).next {
-      no n': s.active - n | less_than [n.id, n'.id, succ.id]
+      no n": s.active - n | less_than [n.id, n".id, succ.id]
       succ != n || #s.active = 1
       succ in s.active
    }
@@ -48,13 +48,13 @@ pred NextCorrect [s: State] {
 pred FingersCorrect [s: State] {
    all nd: s.active.(s.data) | all start: (nd.finger).Node |
       nd.finger[start] in s.active &&
-      (no n' : s.active | less_than [start, n'.id, nd.finger[start].id])
+      (no n" : s.active | less_than [start, n".id, nd.finger[start].id])
 }
 
 pred save_ClosestPrecedingFinger [s: State] {
    all n: s.active | let nd = n.(s.data) |
       all i: Id | let cpf = nd.closest_preceding_finger[i] {
-   no n': (nd.finger[Id] + n) - cpf | less_than [cpf.id, n'.id, i]
+   no n": (nd.finger[Id] + n) - cpf | less_than [cpf.id, n".id, i]
    cpf in nd.finger[Id] + n
    cpf.id != i || # s.active = 1
       }
@@ -97,7 +97,7 @@ pred FindSuccessorIsCorrect[s: State] {
    all i: Id | all n: s.active |
       let succ = (n.(s.data)).find_successor [i] {
          succ in s.active
-         no n': s.active | less_than [i, n'.id, succ.id]
+         no n": s.active | less_than [i, n".id, succ.id]
       }
 }
 
@@ -157,7 +157,7 @@ Suppose we change \tt<ClosestPrecedingFinger> as follows:
 pred ClosestPrecedingFinger [s: State] {
    all n: s.active | let nd = n.(s.data) |
       all i: Id | let cpf = nd.closest_preceding_finger[i] {
-   no n': (nd.finger[Id] + n) - cpf | less_than [cpf.id, n'.id, i]
+   no n": (nd.finger[Id] + n) - cpf | less_than [cpf.id, n".id, i]
    cpf in nd.finger[Id] + n
    cpf.id != i
       }
@@ -184,8 +184,8 @@ n.find_successor(id)
   if (id in (n, n.successor])
     return n.successor;
   else
-    n' = closest_preceding_finger(id);
-    return n'.find_successor(id);
+    n" = closest_preceding_finger(id);
+    return n".find_successor(id);
 
 In the buggy scenario with a single node, the \tt<if> loop
 always terminates at \cite{if-condition1}, leading to an

--- a/algorithms/election/s_ringlead.als
+++ b/algorithms/election/s_ringlead.als
@@ -45,54 +45,54 @@ fact CleanupLast {
     no ls.runs
 }
 
-pred ValidTrans2[s, s': State] {
-  all p : s.runs | VT2Helper[p,s,s']
-  all p : Process - s.runs | NOP2[p,s,s']
-  NoMagicMsg[s,s']
+pred ValidTrans2[s, s": State] {
+  all p : s.runs | VT2Helper[p,s,s"]
+  all p : Process - s.runs | NOP2[p,s,s"]
+  NoMagicMsg[s,s"]
 
 }
 
-pred NoMagicMsg[s, s' : State] {
+pred NoMagicMsg[s, s" : State] {
     // no magically appearing messages
-    all p : Process, m : s'.buffer[p] |
-      m in s.buffer[p] || (!NOP2[p,s,s'] &&
+    all p : Process, m : s".buffer[p] |
+      m in s.buffer[p] || (!NOP2[p,s,s"] &&
                             ((s = so/first && m = p) ||
                              (s != so/first && m in s.buffer[p.~rightNeighbor]
-                              && m !in s'.buffer[p.~rightNeighbor] && po/gt[m,p])))
+                              && m !in s".buffer[p.~rightNeighbor] && po/gt[m,p])))
 }
 
-pred PossTrans[s, s' : State] {
-  all p : Process | VT2Helper[p,s,s'] || NOP2[p,s,s']
-  NoMagicMsg[s,s']
+pred PossTrans[s, s" : State] {
+  all p : Process | VT2Helper[p,s,s"] || NOP2[p,s,s"]
+  NoMagicMsg[s,s"]
 }
 
-pred VT2Helper[p : Process, s, s' : State] {
+pred VT2Helper[p : Process, s, s" : State] {
     (
       let readable=s.buffer[p.~rightNeighbor] |
         (s = so/first) => {
-          p = s'.buffer[p]
-          readable in s'.buffer[p.~rightNeighbor]
-          p !in s'.leader
+          p = s".buffer[p]
+          readable in s".buffer[p.~rightNeighbor]
+          p !in s".leader
         } else {
           (some readable) => {
            some m : set readable | {
-             m !in s'.buffer[p.~rightNeighbor]
+             m !in s".buffer[p.~rightNeighbor]
              // nothing else gets deleted
-             readable - m in s'.buffer[p.~rightNeighbor]
-             { m': m | po/gt[m',p] } /*m & nexts(p)*/ in s'.buffer[p]
-             p in s'.leader iff (p in s.leader || p in m)
+             readable - m in s".buffer[p.~rightNeighbor]
+             { m": m | po/gt[m",p] } /*m & nexts(p)*/ in s".buffer[p]
+             p in s".leader iff (p in s.leader || p in m)
            }
-          } else NOP2[p,s,s']
+          } else NOP2[p,s,s"]
         }
     )
 }
 
-pred NOP2[p : Process, s,s': State] {
-  p in s'.leader iff p in s.leader
+pred NOP2[p : Process, s,s": State] {
+  p in s".leader iff p in s.leader
   // no reads
-  s.buffer[p.~rightNeighbor] in s'.buffer[p.~rightNeighbor]
+  s.buffer[p.~rightNeighbor] in s".buffer[p.~rightNeighbor]
   // no sends
-  s'.buffer[p] in s.buffer[p]
+  s".buffer[p] in s.buffer[p]
 }
 
 pred Preconds[p : Process, s : State] {
@@ -107,13 +107,13 @@ fact TransIfPossible {
 
 fact LegalTrans {
   all s : State - so/last |
-    let s' = so/next[s] |
-      ValidTrans2[s,s']
+    let s" = so/next[s] |
+      ValidTrans2[s,s"]
 }
 
-pred EquivStates[s, s': State] {
-  s.buffer = s'.buffer
-  s.leader = s'.leader
+pred EquivStates[s, s": State] {
+  s.buffer = s".buffer
+  s.leader = s".leader
 }
 
 assert Safety {
@@ -135,7 +135,7 @@ pred BadLivenessTrace {
 
 pred TraceWithoutLoop  {
   all t1, t2 : State | t1!=t2 => !EquivStates[t1,t2]
-  all s, s' : State | (s' in (so/nexts[s] - so/next[s])) => !PossTrans[s,s']
+  all s, s" : State | (s" in (so/nexts[s] - so/next[s])) => !PossTrans[s,s"]
   all s : State | !Legit[s]
 }
 

--- a/algorithms/election/stable_ringlead.als
+++ b/algorithms/election/stable_ringlead.als
@@ -101,9 +101,9 @@ pred TransHelper[p : Process, tp, tn : State] {
 
 }
 
-pred StateTrans[s, s' : State] {
+pred StateTrans[s, s" : State] {
   all p : Process |
-    TransHelper[p, s, s'] || ValAtState[p,s] = ValAtState[p,s']
+    TransHelper[p, s, s"] || ValAtState[p,s] = ValAtState[p,s"]
 }
 
 
@@ -130,14 +130,14 @@ pred BadLivenessHelper {
 
 pred CTraceWithoutLoop {
   OneAtATimeTrans
-  all t, t' : State | t!=t' => t.val != t'.val
+  all t, t" : State | t!=t" => t.val != t".val
 }
 
 pred DTraceWithoutLoop {
   DDaemonTrans
-  all t, t' : State | t!=t' => {
-    t.val != t'.val
-    (t' in so/nexts[t] && t' != so/next[t]) => !StateTrans[t,t']
+  all t, t" : State | t!=t" => {
+    t.val != t".val
+    (t" in so/nexts[t] && t" != so/next[t]) => !StateTrans[t,t"]
   }
   all t : State | !Legit[t]
 }
@@ -150,9 +150,9 @@ pred ConvergingRun  {
 
 pred OnlyFairLoops {
   OneAtATimeTrans
-  all s, s' : State |
-   (s' in so/nexts[s] && s'.val = s.val) =>
-     (let loopStates = (so/nexts[s] & so/prevs[s']) + s + s' | Process in loopStates.running)
+  all s, s" : State |
+   (s" in so/nexts[s] && s".val = s.val) =>
+     (let loopStates = (so/nexts[s] & so/prevs[s"]) + s + s" | Process in loopStates.running)
 }
 
 assert CMustConverge {
@@ -165,9 +165,9 @@ pred Legit [s : State] {
     int XAtState[p,s] < # Val
     int YAtState[p,s] < # Val
   }
-  all p, p' : Process | {
-    int XAtState[p,s] = int XAtState[p',s]
-    int YAtState[p,s] = int YAtState[p',s]
+  all p, p" : Process | {
+    int XAtState[p,s] = int XAtState[p",s]
+    int YAtState[p,s] = int YAtState[p",s]
   }
 }
 

--- a/algorithms/gc/marksweepgc.als
+++ b/algorithms/gc/marksweepgc.als
@@ -11,12 +11,12 @@ sig HeapState {
   freeList : lone Node
 }
 
-pred clearMarks[hs, hs' : HeapState] {
+pred clearMarks[hs, hs" : HeapState] {
   // clear marked set
-  no hs'.marked
+  no hs".marked
   // left and right fields are unchanged
-  hs'.left = hs.left
-  hs'.right = hs.right
+  hs".left = hs.left
+  hs".right = hs.right
 }
 
 /**
@@ -26,54 +26,54 @@ fun reachable[hs: HeapState, n: Node] : set Node {
   n + n.^(hs.left + hs.right)
 }
 
-pred mark[hs: HeapState, from : Node, hs': HeapState] {
-  hs'.marked = hs.reachable[from]
-  hs'.left = hs.left
-  hs'.right = hs.right
+pred mark[hs: HeapState, from : Node, hs": HeapState] {
+  hs".marked = hs.reachable[from]
+  hs".left = hs.left
+  hs".right = hs.right
 }
 
 /**
  * complete hack to simulate behavior of code to set freeList
  */
-pred setFreeList[hs, hs': HeapState] {
+pred setFreeList[hs, hs": HeapState] {
   // especially hackish
-  hs'.freeList.*(hs'.left) in (Node - hs.marked)
+  hs".freeList.*(hs".left) in (Node - hs.marked)
   all n: Node |
     (n !in hs.marked) => {
-      no hs'.right[n]
-      hs'.left[n] in (hs'.freeList.*(hs'.left))
-      n in hs'.freeList.*(hs'.left)
+      no hs".right[n]
+      hs".left[n] in (hs".freeList.*(hs".left))
+      n in hs".freeList.*(hs".left)
     } else {
-      hs'.left[n] = hs.left[n]
-      hs'.right[n] = hs.right[n]
+      hs".left[n] = hs.left[n]
+      hs".right[n] = hs.right[n]
     }
-  hs'.marked = hs.marked
+  hs".marked = hs.marked
 }
 
-pred GC[hs: HeapState, root : Node, hs': HeapState] {
+pred GC[hs: HeapState, root : Node, hs": HeapState] {
   some hs1, hs2: HeapState |
-    hs.clearMarks[hs1] && hs1.mark[root, hs2] && hs2.setFreeList[hs']
+    hs.clearMarks[hs1] && hs1.mark[root, hs2] && hs2.setFreeList[hs"]
 }
 
 assert Soundness1 {
-  all h, h' : HeapState, root : Node |
-    h.GC[root, h'] =>
+  all h, h" : HeapState, root : Node |
+    h.GC[root, h"] =>
       (all live : h.reachable[root] | {
-        h'.left[live] = h.left[live]
-        h'.right[live] = h.right[live]
+        h".left[live] = h.left[live]
+        h".right[live] = h.right[live]
       })
 }
 
 assert Soundness2 {
-  all h, h' : HeapState, root : Node |
-    h.GC[root, h'] =>
-      no h'.reachable[root] & h'.reachable[h'.freeList]
+  all h, h" : HeapState, root : Node |
+    h.GC[root, h"] =>
+      no h".reachable[root] & h".reachable[h".freeList]
 }
 
 assert Completeness {
-  all h, h' : HeapState, root : Node |
-    h.GC[root, h'] =>
-      (Node - h'.reachable[root]) in h'.reachable[h'.freeList]
+  all h, h" : HeapState, root : Node |
+    h.GC[root, h"] =>
+      (Node - h".reachable[root]) in h".reachable[h".freeList]
 }
 
 check Soundness1 for 3 expect 0

--- a/algorithms/mapping/view-backing.als
+++ b/algorithms/mapping/view-backing.als
@@ -30,8 +30,8 @@
  *
  * As a terminological convention, when there are two
  * complementary view relationships, we will give them types
- * t and t'. For example, KeySetView propagates from map to
- * set, and KeySetView' propagates from set to map.
+ * t and t". For example, KeySetView propagates from map to
+ * set, and KeySetView" propagates from set to map.
  *
  * author: Daniel Jackson
  */
@@ -74,12 +74,12 @@ sig SetRef extends Ref {}
 fact {State.obj[SetRef] in Set}
 
 abstract sig ViewType {}
-one sig KeySetView, KeySetView', IteratorView extends ViewType {}
+one sig KeySetView, KeySetView", IteratorView extends ViewType {}
 fact ViewTypes {
   State.views[KeySetView] in MapRef -> SetRef
-  State.views[KeySetView'] in SetRef -> MapRef
+  State.views[KeySetView"] in SetRef -> MapRef
   State.views[IteratorView] in IteratorRef -> SetRef
-  all s: State | s.views[KeySetView] = ~(s.views[KeySetView'])
+  all s: State | s.views[KeySetView] = ~(s.views[KeySetView"])
   }
 
 /**
@@ -105,20 +105,20 @@ pred allocates [pre, post: State, rs: set Ref] {
   }
 
 /** 
- * models frame condition that limits change to view object from v to v' when backing object changes to b'
+ * models frame condition that limits change to view object from v to v" when backing object changes to b"
  */
-pred viewFrame [t: ViewType, v, v', b': Object] {
-  t in KeySetView => v'.elts = dom [b'.map]
-  t in KeySetView' => b'.elts = dom [v'.map]
-  t in KeySetView' => (b'.elts) <: (v.map) = (b'.elts) <: (v'.map)
-  t in IteratorView => v'.elts = b'.left + b'.done
+pred viewFrame [t: ViewType, v, v", b": Object] {
+  t in KeySetView => v".elts = dom [b".map]
+  t in KeySetView" => b".elts = dom [v".map]
+  t in KeySetView" => (b".elts) <: (v.map) = (b".elts) <: (v".map)
+  t in IteratorView => v".elts = b".left + b".done
   }
 
 pred MapRef.keySet [pre, post: State, setRefs: SetRef] {
   post.obj[setRefs].elts = dom [pre.obj[this].map]
   modifies [pre, post, none]
   allocates [pre, post, setRefs]
-  post.views = pre.views + KeySetView->this->setRefs + KeySetView'->setRefs->this
+  post.views = pre.views + KeySetView->this->setRefs + KeySetView"->setRefs->this
   }
 
 pred MapRef.put [pre, post: State, k, v: Ref] {
@@ -139,10 +139,10 @@ pred SetRef.iterator [pre, post: State, iterRef: IteratorRef] {
   }
 
 pred IteratorRef.remove [pre, post: State] {
-  let i = pre.obj[this], i' = post.obj[this] {
-    i'.left = i.left
-    i'.done = i.done - i.lastRef
-    no i'.lastRef
+  let i = pre.obj[this], i" = post.obj[this] {
+    i".left = i.left
+    i".done = i.done - i.lastRef
+    no i".lastRef
     }
   modifies [pre,post,this]
   allocates [pre, post, none]
@@ -150,11 +150,11 @@ pred IteratorRef.remove [pre, post: State] {
   }
 
 pred IteratorRef.next [pre, post: State, ref: Ref] {
-  let i = pre.obj[this], i' = post.obj[this] {
+  let i = pre.obj[this], i" = post.obj[this] {
     ref in i.left
-    i'.left = i.left - ref
-    i'.done = i.done + ref
-    i'.lastRef = ref
+    i".left = i.left - ref
+    i".done = i.done + ref
+    i".lastRef = ref
     }
   modifies [pre, post, this]
   allocates [pre, post, none]

--- a/algorithms/multicasting/iolus.als
+++ b/algorithms/multicasting/iolus.als
@@ -40,9 +40,9 @@ abstract sig KDS {
   members : Tick -> Member
 }{
   Monotonic[keys]
-  all t : Tick | let t' = ord/prev[t] {
-    all m : members[t]-members[t'] | Join[m, t, this]
-    all m : members[t']-members[t] | Leave[m, t]
+  all t : Tick | let t" = ord/prev[t] {
+    all m : members[t]-members[t"] | Join[m, t, this]
+    all m : members[t"]-members[t] | Leave[m, t]
   }
 }
 
@@ -84,8 +84,8 @@ sig DataMessage extends Message {
   gsaID : GSA,
   retransmitTime : Tick }
 { SendMessage[sender, sentTime, this] ||
-  (some msg' : DataMessage |
-     Remulticast[gsaID, msg', retransmitTime, this]) }
+  (some msg" : DataMessage |
+     Remulticast[gsaID, msg", retransmitTime, this]) }
 
 sig GSA extends KDS {
   parent : lone GSA }
@@ -99,9 +99,9 @@ sig Client extends Member {
     k.generator = server && k.generatedTime = t }
 
 fact IolusProperties {
-  no k, k' : GroupKey | k!=k' && k.generator = k'.generator && k.generatedTime = k'.generatedTime
+  no k, k" : GroupKey | k!=k" && k.generator = k".generator && k.generatedTime = k".generatedTime
   all g : GSA, msg : DataMessage, t : Tick | RemulticastConditions[g, msg, t] =>
-    (some msg': DataMessage | Remulticast[g, msg, t, msg'])
+    (some msg": DataMessage | Remulticast[g, msg, t, msg"])
 }
 
 fact GSATree {
@@ -114,13 +114,13 @@ fact {
   KDS = GSA
   Message = DataMessage
   Key = GroupKey
-  no m, m' : DataMessage {
-    m!=m'
-    m.sender = m'.sender
-    m.sentTime = m'.sentTime
-    m.key = m'.key
-    m.gsaID = m'.gsaID
-    m.retransmitTime = m'.retransmitTime }
+  no m, m" : DataMessage {
+    m!=m"
+    m.sender = m".sender
+    m.sentTime = m".sentTime
+    m.key = m".key
+    m.gsaID = m".gsaID
+    m.retransmitTime = m".retransmitTime }
 }
 
 ----------------------------------------------
@@ -162,7 +162,7 @@ pred SendRequest[c : Client, gsa : GSA, t : Tick, msg : DataMessage] {
   msg.gsaID = gsa
   msg.retransmitTime = t
   (some gsa.parent.members[t]) =>
-    (some msg' : DataMessage | Remulticast[gsa, msg, t, msg']) }
+    (some msg" : DataMessage | Remulticast[gsa, msg, t, msg"]) }
 
 pred ReceiveMessage[m : Member, t : Tick, msg : Message] {
   ReceiveConditions[m, t, msg]
@@ -179,10 +179,10 @@ pred ReceiveConditions[m : Member, t : Tick, msg : Message] {
   msg.key in m.ownedKeys[t] }
 
 pred CanReceive[m : Member, t : Tick, msg : Message] {
-  some msg' : DataMessage {
-    msg'.sentTime = msg.sentTime
-    msg'.sender = msg.sender
-    msg' in m.receivedMessages[ord/prev[t]] || ReceiveConditions[m, t, msg'] }}
+  some msg" : DataMessage {
+    msg".sentTime = msg.sentTime
+    msg".sender = msg.sender
+    msg" in m.receivedMessages[ord/prev[t]] || ReceiveConditions[m, t, msg"] }}
 
 pred IsMember[m : Member, t : Tick] {
   some kds : KDS | m in kds.members[t]
@@ -194,13 +194,13 @@ pred RemulticastConditions[g : GSA, msg : DataMessage, t : Tick] {
   msg.key in g.keys[t] + g.parent.keys[t]
   some g.parent + g - msg.gsaID }
 
-pred Remulticast[g : GSA, msg : DataMessage, t : Tick, msg': lone DataMessage] {
+pred Remulticast[g : GSA, msg : DataMessage, t : Tick, msg": lone DataMessage] {
   RemulticastConditions[g, msg, t]
-  let g' = g.parent + g - msg.gsaID | NewestKey[g'.keys[msg.sentTime], msg'.key]
-  msg'.sender = msg.sender
-  msg'.sentTime = msg.sentTime
-  msg'.retransmitTime = t
-  msg'.gsaID = g
+  let g" = g.parent + g - msg.gsaID | NewestKey[g".keys[msg.sentTime], msg".key]
+  msg".sender = msg.sender
+  msg".sentTime = msg.sentTime
+  msg".retransmitTime = t
+  msg".gsaID = g
 }
 
 pred KeyUpdate[g : GSA, t : Tick] {
@@ -234,7 +234,7 @@ assert Acyclic {
 //check Acyclic for 6 -- one min
 
 assert Connected {
-  all g, g' : GSA | g in g'.*(parent + ~parent) }
+  all g, g" : GSA | g in g".*(parent + ~parent) }
 
 //check Connected for 6
 
@@ -244,17 +244,17 @@ assert TimeProceeds {
 //check TimeProceeds for 6
 
 pred LoopFree {
-  no t, t' : Tick {
-    t!=t'
-    all k : KDS | k.members[t] = k.members[t'] -- no constraint on keys
-    all m : Member | m.receivedMessages[t] = m.receivedMessages[t']
+  no t, t" : Tick {
+    t!=t"
+    all k : KDS | k.members[t] = k.members[t"] -- no constraint on keys
+    all m : Member | m.receivedMessages[t] = m.receivedMessages[t"]
     all m : DataMessage | m.retransmitTime = t =>
-      (some m' : DataMessage {
-        m'.retransmitTime = t'
-        m.sender = m'.sender
-        m.sentTime = m'.sentTime
-        m.gsaID = m'.gsaID
-        m.key = m'.key })
+      (some m" : DataMessage {
+        m".retransmitTime = t"
+        m.sender = m".sender
+        m.sentTime = m".sentTime
+        m.gsaID = m".gsaID
+        m.key = m".key })
     }}
 
 //fact NoLoop { LoopFree() } -- Property-specific diameter
@@ -266,7 +266,7 @@ assert loop {
 
 assert NonLinearTopology {
   (no g : GSA | #g.~parent > 1) ||
-  !(some m, m' : DataMessage | Remulticast[m.gsaID, m', m.retransmitTime, m]
+  !(some m, m" : DataMessage | Remulticast[m.gsaID, m", m.retransmitTime, m]
     && !SendMessage[m.sender, m.sentTime, m]
     && (some c : Client | m in c.receivedMessages[ord/nexts[m.retransmitTime]]))}
 
@@ -284,8 +284,8 @@ assert Trivial {
 
 assert x {
   !(LoopFree && some DataMessage &&
-     (some t : Tick | some m, m' : Member |
-        m!=m' && IsMember[m, t] && IsMember[m', t] && t != ord/next[ord/first]))
+     (some t : Tick | some m, m" : Member |
+        m!=m" && IsMember[m, t] && IsMember[m", t] && t != ord/next[ord/first]))
 }
 
 //check x for 3 but 2 Member, 2 KDS, 2 Message
@@ -307,9 +307,9 @@ assert OutsiderCantSend {
 }
 assert InsiderCanRead {
   all msg : Message, m : Member |
-    some t : Tick - ord/last | all t' : ord/nexts[t] |
+    some t : Tick - ord/last | all t" : ord/nexts[t] |
       (IsMember[msg.sender, msg.sentTime] &&
-       IsMember[m, msg.sentTime]) => CanReceive[m, t', msg]
+       IsMember[m, msg.sentTime]) => CanReceive[m, t", msg]
 }
 
 check OutsiderCantRead for 5 but 3 Member expect 0

--- a/algorithms/mutex/dijkstra-2-process.als
+++ b/algorithms/mutex/dijkstra-2-process.als
@@ -33,50 +33,50 @@ pred IsFree [s: State, m: Mutex] {
 
 pred IsStalled [s: State, p: Process] { some p.(s.waits) }
 
-pred GrabMutex [s: State, p: Process, m: Mutex, s': State] {
+pred GrabMutex [s: State, p: Process, m: Mutex, s": State] {
    // a process can only act if it is not
    // waiting for a mutex
    !s.IsStalled[p]
    // can only grab a mutex we do not yet hold
    m !in p.(s.holds)
    // mutexes are grabbed in order
-   all m': p.(s.holds) | mo/lt[m',m]
+   all m": p.(s.holds) | mo/lt[m",m]
    s.IsFree[m] => {
       // if the mutex is free, we now hold it,
       // and do not become stalled
-      p.(s'.holds) = p.(s.holds) + m
-      no p.(s'.waits)
+      p.(s".holds) = p.(s.holds) + m
+      no p.(s".waits)
    } else {
     // if the mutex was not free,
     // we still hold the same mutexes we held,
     // and are now waiting on the mutex
     // that we tried to grab.
-    p.(s'.holds) = p.(s.holds)
-    p.(s'.waits) = m
+    p.(s".holds) = p.(s.holds)
+    p.(s".waits) = m
   }
   all otherProc: Process - p | {
-     otherProc.(s'.holds) = otherProc.(s.holds)
-     otherProc.(s'.waits) = otherProc.(s.waits)
+     otherProc.(s".holds) = otherProc.(s.holds)
+     otherProc.(s".waits) = otherProc.(s.waits)
   }
 }
 
-pred ReleaseMutex [s: State, p: Process, m: Mutex, s': State] {
+pred ReleaseMutex [s: State, p: Process, m: Mutex, s": State] {
    !s.IsStalled[p]
    m in p.(s.holds)
-   p.(s'.holds) = p.(s.holds) - m
-   no p.(s'.waits)
+   p.(s".holds) = p.(s.holds) - m
+   no p.(s".waits)
    no m.~(s.waits) => {
-      no m.~(s'.holds)
-      no m.~(s'.waits)
+      no m.~(s".holds)
+      no m.~(s".waits)
    } else {
       some lucky: m.~(s.waits) | {
-        m.~(s'.waits) = m.~(s.waits) - lucky
-        m.~(s'.holds) = lucky
+        m.~(s".waits) = m.~(s.waits) - lucky
+        m.~(s".holds) = lucky
       }
    }
   all mu: Mutex - m {
-    mu.~(s'.waits) = mu.~(s.waits)
-    mu.~(s'.holds)= mu.~(s.holds)
+    mu.~(s".waits) = mu.~(s.waits)
+    mu.~(s".holds)= mu.~(s.holds)
   }
 }
 

--- a/algorithms/spanning-tree/opt_spantree.als
+++ b/algorithms/spanning-tree/opt_spantree.als
@@ -145,14 +145,14 @@ fact TransIfPossible {
 fact LegalTrans {
   Init
   all s : State - so/last |
-    let s' = so/next[s] | {
+    let s" = so/next[s] | {
       all p : Process |
-        p in s.runs => Trans[p, s, s'] else TRNop[p,s,s']
+        p in s.runs => Trans[p, s, s"] else TRNop[p,s,s"]
     }
 }
 
-pred PossTrans[s, s' : State] {
-  all p : Process | Trans[p,s,s']
+pred PossTrans[s, s" : State] {
+  all p : Process | Trans[p,s,s"]
 }
 
 pred SpanTreeAtState[s : State] {
@@ -178,9 +178,9 @@ pred SuccessfulRun {
  * show a trace without a loop
  */
 pred TraceWithoutLoop {
-  all s, s' : State | s!=s' => {
-    !EquivStates[s, s']
-    (s' in so/nexts[s] && (s' != so/next[s])) => !PossTrans[s,s']
+  all s, s" : State | s!=s" => {
+    !EquivStates[s, s"]
+    (s" in so/nexts[s] && (s" != so/next[s])) => !PossTrans[s,s"]
   }
   all s: State | !SpanTreeAtState[s]
 }
@@ -188,9 +188,9 @@ pred TraceWithoutLoop {
 /**
  * defines equivalent states
  */
-pred EquivStates[s, s' : State] {
-  s.lvl = s'.lvl
-  s.parent = s'.parent
+pred EquivStates[s, s" : State] {
+  s.lvl = s".lvl
+  s.parent = s".parent
 }
 
 /**
@@ -198,7 +198,7 @@ pred EquivStates[s, s' : State] {
  */
 pred BadLivenessTrace {
   // two different states equivalent (loop)
-  some s, s' : State | s!=s' && EquivStates[s, s']
+  some s, s" : State | s!=s" && EquivStates[s, s"]
   all s : State | !SpanTreeAtState[s]
 }
 

--- a/algorithms/synchronisation/sync.als
+++ b/algorithms/synchronisation/sync.als
@@ -74,9 +74,9 @@ fun RestrictFSComplement[fs: Name -> lone FileContents, p: Name]: Name -> lone F
  * A,B - separately modified copies
  * Adirty, Bdirty - sets of paths modified in A and B, respectively, from O.
  *
- * A',B' - results of synchronizer operation
+ * A",B" - results of synchronizer operation
  */
-pred SyncSpec[A, B, A', B': Name -> lone FileContents, Adirty, Bdirty: set Name] {
+pred SyncSpec[A, B, A", B": Name -> lone FileContents, Adirty, Bdirty: set Name] {
   {
      IsValidFS[A]
      IsValidFS[B]
@@ -85,19 +85,19 @@ pred SyncSpec[A, B, A', B': Name -> lone FileContents, Adirty, Bdirty: set Name]
    } => {
     {
      all p: Name | IsRelevantPath[p, A, B] => {
-        SyncSpecForPath[p, A, B, A', B', Adirty, Bdirty]
+        SyncSpecForPath[p, A, B, A", B", Adirty, Bdirty]
      }
     }
-    IsValidFS[A']
-    IsValidFS[B']
+    IsValidFS[A"]
+    IsValidFS[B"]
    }
 }
 
-pred SyncSpecForPath[p: Name, A, B, A', B': Name -> lone FileContents, Adirty, Bdirty: set Name] {
-      (p.A = p.B  =>  (p.A' = p.A && p.B' = p.B))
-      (p !in Adirty => (RestrictFS[A', p] = RestrictFS[B, p] && RestrictFS[B', p] = RestrictFS[B, p]))
-      (p !in Bdirty => (RestrictFS[B', p] = RestrictFS[A, p] && RestrictFS[A', p] = RestrictFS[A, p]))
-      ((p in Adirty && p in Bdirty && p.A != p.B) => (RestrictFS[A',p] = RestrictFS[A,p] && RestrictFS[B',p] = RestrictFS[B,p]))
+pred SyncSpecForPath[p: Name, A, B, A", B": Name -> lone FileContents, Adirty, Bdirty: set Name] {
+      (p.A = p.B  =>  (p.A" = p.A && p.B" = p.B))
+      (p !in Adirty => (RestrictFS[A", p] = RestrictFS[B, p] && RestrictFS[B", p] = RestrictFS[B, p]))
+      (p !in Bdirty => (RestrictFS[B", p] = RestrictFS[A, p] && RestrictFS[A", p] = RestrictFS[A, p]))
+      ((p in Adirty && p in Bdirty && p.A != p.B) => (RestrictFS[A",p] = RestrictFS[A,p] && RestrictFS[B",p] = RestrictFS[B,p]))
 }
 
 pred IsRelevantPath[p: Name, A, B: Name -> lone FileContents] {
@@ -107,25 +107,25 @@ pred IsRelevantPath[p: Name, A, B: Name -> lone FileContents] {
    }
 }
 
-pred SyncSpecExample[A, B, A', B': Name -> lone FileContents, Adirty, Bdirty: set Name] {
+pred SyncSpecExample[A, B, A", B": Name -> lone FileContents, Adirty, Bdirty: set Name] {
    IsValidFS[A]
    IsValidFS[B]
    IsValidDirty[Adirty]
    IsValidDirty[Bdirty]
-   SyncSpec[A, B, A', B', Adirty, Bdirty]
-   A != A'
+   SyncSpec[A, B, A", B", Adirty, Bdirty]
+   A != A"
 }
 
 //run SyncSpecExample for 3
 
 pred SyncSpecNotUnique  {
-  some A, B, A1', B1', A2', B2': Name -> lone FileContents, Adirty, Bdirty: set Name | {
+  some A, B, A1", B1", A2", B2": Name -> lone FileContents, Adirty, Bdirty: set Name | {
     IsValidFS[A] && IsValidFS[B]
     IsValidDirty[Adirty] && IsValidDirty[Bdirty]
     //DirtiesValid(A, B, Adirty, Bdirty)
-    (A1' != A2'  || B1' != B2')
-    SyncSpec[A, B, A1', B1', Adirty, Bdirty]
-    SyncSpec[A, B, A2', B2', Adirty, Bdirty]
+    (A1" != A2"  || B1" != B2")
+    SyncSpec[A, B, A1", B1", Adirty, Bdirty]
+    SyncSpec[A, B, A2", B2", Adirty, Bdirty]
   }
 }
 

--- a/algorithms/synchronisation/syncimpl.als
+++ b/algorithms/synchronisation/syncimpl.als
@@ -45,9 +45,9 @@ fun ChildrenAB[A, B: Name -> lone FileContents, p: Name]: set Name {
 
 pred reconHelper[Adirty, Bdirty: set Name] {
    all p: Name {
-      let A = p.Ain, B = p.Bin, A' = p.Aout, B' = p.Bout | {
+      let A = p.Ain, B = p.Bin, A" = p.Aout, B" = p.Bout | {
          some p.(A+B) => {
-             (p !in Adirty && p !in Bdirty) => (A' = A  && B' = B)  else {
+             (p !in Adirty && p !in Bdirty) => (A" = A  && B" = B)  else {
              (p.A = Dir && p.B = Dir) => {
                 no p_children => {
                   p.Aout = p.Ain
@@ -64,41 +64,41 @@ pred reconHelper[Adirty, Bdirty: set Name] {
                 }  // some p_children
              } else {  // !(p.A = Dir && p.B = Dir)
                p !in Adirty => {
-                 A' = RestrictFS[B, p] + RestrictFSComplement[A, p]
-                 B' = B
+                 A" = RestrictFS[B, p] + RestrictFSComplement[A, p]
+                 B" = B
                } else {
                   p !in Bdirty => {
-                     A' = A
-                     B' = RestrictFS[A, p] + RestrictFSComplement[B, p]
+                     A" = A
+                     B" = RestrictFS[A, p] + RestrictFSComplement[B, p]
                   } else {
-                     A' = A
-                     B' = B
+                     A" = A
+                     B" = B
                   }
                }  // not "p !in Adirty"
              }  // not case 2 i.e. not both are dirs
           }  // not both clean
        }  // some p.(A+B)
-      }  // let A =, B=, A'=, B'=
+      }  // let A =, B=, A"=, B"=
     } // all p: Name
 }  // reconHelper()
 
-pred recon[A, B, A', B': Name -> lone FileContents, Adirty, Bdirty: set Name] {
+pred recon[A, B, A", B": Name -> lone FileContents, Adirty, Bdirty: set Name] {
    A = ReconName.Ain
    B = ReconName.Bin
-   A' = ReconName.Aout
-   B' = ReconName.Bout
+   A" = ReconName.Aout
+   B" = ReconName.Bout
    reconHelper[Adirty, Bdirty]
 }
 
 assert Correctness {
-  all A, B, A', B': Name -> lone FileContents, Adirty, Bdirty: set Name | {
+  all A, B, A", B": Name -> lone FileContents, Adirty, Bdirty: set Name | {
     {
      DirtiesValid[A, B, Adirty, Bdirty]
-     recon[A, B, A', B', Adirty, Bdirty]
+     recon[A, B, A", B", Adirty, Bdirty]
      //no Adirty + Bdirty
     }
     =>
-     SyncSpec[A, B, A', B', Adirty, Bdirty]
+     SyncSpec[A, B, A", B", Adirty, Bdirty]
   }
 }
 

--- a/models/firewire/firewire.als
+++ b/models/firewire/firewire.als
@@ -99,7 +99,7 @@
  * skolemized away by the analyzer.
  *
  * The {\em functions} of the model are parameterized formulas. The function {\em
- * Trans} relates a pre-state {\tt s} to a post-state {\tt s'}. It has a case for
+ * Trans} relates a pre-state {\tt s} to a post-state {\tt s"}. It has a case for
  * each operation. Look at the clause for the operation {\em WriteReqOrAck}, for
  * example. If this operation is deemed to have occurred, each of the constraints
  * in the curly braces must hold. The first says that the labelling of links as
@@ -117,8 +117,8 @@
  * new queue in the post-state (given the local name {\tt q}) contains the message
  * {\tt m} in its slot, and has no message in its overflow. Otherwise, some
  * message is placed arbitrarily in the overflow, and the slot is
- * unconstrained. In {\em WriteReqOrAck}, the arguments {\tt s} and {\tt s'} are
- * bound to the {\tt s} and {\tt s'} of {\em Trans}; {\tt x} is bound to one of
+ * unconstrained. In {\em WriteReqOrAck}, the arguments {\tt s} and {\tt s"} are
+ * bound to the {\tt s} and {\tt s"} of {\em Trans}; {\tt x} is bound to one of
  * the outgoing links from the set {\tt n.from}; and {\tt msg} is bound either to
  * the acknowledgment or request message.
  *
@@ -207,99 +207,99 @@ sig State {
   waiting + active + contending + elected = Node
 }
 
-pred SameState [s, s': State] {
-  s.waiting = s'.waiting
-  s.active = s'.active
-  s.contending = s'.contending
-  s.elected = s'.elected
-  s.parentLinks = s'.parentLinks
-  all x: Link | SameQueue [s.queue[x], s'.queue[x]]
+pred SameState [s, s": State] {
+  s.waiting = s".waiting
+  s.active = s".active
+  s.contending = s".contending
+  s.elected = s".elected
+  s.parentLinks = s".parentLinks
+  all x: Link | SameQueue [s.queue[x], s".queue[x]]
   }
 
-pred Trans [s, s': State] {
-  s'.op != Init
-  s'.op = Stutter => SameState [s, s']
-  s'.op = AssignParent => {
+pred Trans [s, s": State] {
+  s".op != Init
+  s".op = Stutter => SameState [s, s"]
+  s".op = AssignParent => {
     some x: Link {
-      x.target in s.waiting & s'.waiting
-      NoChangeExceptAt [s, s', x.target]
+      x.target in s.waiting & s".waiting
+      NoChangeExceptAt [s, s", x.target]
       ! IsEmptyQueue [s, x]
-      s'.parentLinks = s.parentLinks + x
-      ReadQueue [s, s', x]
+      s".parentLinks = s.parentLinks + x
+      ReadQueue [s, s", x]
       }}
-  s'.op = ReadReqOrAck => {
-    s'.parentLinks = s.parentLinks
+  s".op = ReadReqOrAck => {
+    s".parentLinks = s.parentLinks
     some x: Link {
-      x.target in s.(active + contending) & (PeekQueue [s, x, Ack] => s'.contending else s'.active)
-      NoChangeExceptAt [s, s', x.target]
+      x.target in s.(active + contending) & (PeekQueue [s, x, Ack] => s".contending else s".active)
+      NoChangeExceptAt [s, s", x.target]
       ! IsEmptyQueue [s, x]
-      ReadQueue [s', s, x]
+      ReadQueue [s", s, x]
       }}
-  s'.op = Elect => {
-    s'.parentLinks = s.parentLinks
+  s".op = Elect => {
+    s".parentLinks = s.parentLinks
     some n: Node {
-      n in s.active & s'.elected
-      NoChangeExceptAt [s, s', n]
+      n in s.active & s".elected
+      NoChangeExceptAt [s, s", n]
       n.to in s.parentLinks
-      QueuesUnchanged [s, s', Link]
+      QueuesUnchanged [s, s", Link]
       }}
-  s'.op = WriteReqOrAck => {
+  s".op = WriteReqOrAck => {
     -- note how this requires access to child ptr
-    s'.parentLinks = s.parentLinks
+    s".parentLinks = s.parentLinks
     some n: Node {
-      n in s.waiting & s'.active
+      n in s.waiting & s".active
       lone n.to - s.parentLinks
-      NoChangeExceptAt [s, s', n]
+      NoChangeExceptAt [s, s", n]
       all x: n.from |
         let msg = (x.reverse in s.parentLinks => Ack else Req) |
-          WriteQueue [s, s', x, msg]
-      QueuesUnchanged [s, s', Link - n.from]
+          WriteQueue [s, s", x, msg]
+      QueuesUnchanged [s, s", Link - n.from]
       }}
-  s'.op = ResolveContention => {
+  s".op = ResolveContention => {
     some x: Link {
       let contenders = x.(source + target) {
-        contenders in s.contending & s'.active
-        NoChangeExceptAt [s, s', contenders]
+        contenders in s.contending & s".active
+        NoChangeExceptAt [s, s", contenders]
         }
-      s'.parentLinks = s.parentLinks + x
+      s".parentLinks = s.parentLinks + x
       }
-    QueuesUnchanged [s, s', Link]
+    QueuesUnchanged [s, s", Link]
     }
 }
 
-pred NoChangeExceptAt [s, s': State, nodes: set Node] {
+pred NoChangeExceptAt [s, s": State, nodes: set Node] {
   let ns = Node - nodes {
-  ns & s.waiting = ns & s'.waiting
-  ns & s.active = ns & s'.active
-  ns & s.contending = ns & s'.contending
-  ns & s.elected = ns & s'.elected
+  ns & s.waiting = ns & s".waiting
+  ns & s.active = ns & s".active
+  ns & s.contending = ns & s".contending
+  ns & s.elected = ns & s".elected
   }}
 
 sig Queue {slot: lone Msg, overflow: lone Msg}
 
-pred SameQueue [q, q': Queue] {
-    q.slot = q'.slot && q.overflow = q'.overflow
+pred SameQueue [q, q": Queue] {
+    q.slot = q".slot && q.overflow = q".overflow
   }
 
-pred ReadQueue [s, s': State, x: Link] {
---  let q = s'.queue[x] | no q.(slot + overflow)
-  no s'.queue[x].(slot + overflow)
-  all x': Link - x | s'.queue[x'] = s.queue[x']
+pred ReadQueue [s, s": State, x: Link] {
+--  let q = s".queue[x] | no q.(slot + overflow)
+  no s".queue[x].(slot + overflow)
+  all x": Link - x | s".queue[x"] = s.queue[x"]
   }
 
 pred PeekQueue [s: State, x: Link, m: Msg] {
   m = s.queue[x].slot
   }
 
-pred WriteQueue [s, s': State, x: Link, m: Msg] {
-        let q = s'.queue[x] |
+pred WriteQueue [s, s": State, x: Link, m: Msg] {
+        let q = s".queue[x] |
   no s.queue[x].slot =>
     ( q.slot = m && no q.overflow) else
     some q.overflow
   }
 
-pred QueuesUnchanged [s, s': State, xs: set Link] {
-  all x: xs | s'.queue[x] = s.queue[x]
+pred QueuesUnchanged [s, s": State, xs: set Link] {
+  all x: xs | s".queue[x] = s.queue[x]
   }
 
 pred IsEmptyQueue [s: State, x: Link] {
@@ -316,7 +316,7 @@ pred Initialization [s: State] {
 
 pred Execution  {
   Initialization [ord/first]
-  all s: State - ord/last | let s' = ord/next[s] | Trans [s, s']
+  all s: State - ord/last | let s" = ord/next[s] | Trans [s, s"]
   }
 
 pred ElectionHappens {
@@ -327,7 +327,7 @@ pred ElectionHappens {
 
 pred NoRepeats {
   Execution
-  no s, s': State | s!=s' && SameState [s, s']
+  no s, s": State | s!=s" && SameState [s, s"]
   no s: State | s.op = Stutter
   }
 

--- a/models/java/java-map.als
+++ b/models/java/java-map.als
@@ -35,24 +35,24 @@ fun Map.get( k : Object ) : Object {
 	let v = this.entries[k] | one v implies v else null
 }
 
-pred Map.put( m' : Map,  k, v, r : Object ) {
+pred Map.put( m" : Map,  k, v, r : Object ) {
 	this.get[k] = r
-	m'.entries = this.entries ++ k -> v	
+	m".entries = this.entries ++ k -> v
 }
 
-pred Map.remove( m' : Map,  k, r: Object ) {
+pred Map.remove( m" : Map,  k, r: Object ) {
 	this.containsKey[k] 
 		implies { 
-					m'.entries = this.entries - k->Object
+					m".entries = this.entries - k->Object
 			and	this.get[k] = r
 		} else {
 			r = null
-			m'.entries = this.entries
+			m".entries = this.entries
 		}
 }
 
-pred Map.putAll( m', other : Map ) {
-	m'.entries = this.entries ++ other.entries
+pred Map.putAll( m", other : Map ) {
+	m".entries = this.entries ++ other.entries
 }
 
 fun Map.keySet : set Object {
@@ -63,8 +63,8 @@ fun Map.values : set Object {
 	this.entries[Object]
 }
 
-pred Map.clear( m' : Map ) {
-	m'.isEmpty
+pred Map.clear( m" : Map ) {
+	m".isEmpty
 }
 
 fun Map.entrySet : Object -> Object {
@@ -76,21 +76,21 @@ pred equals( a,b : Map ) {
 	all k : a.keySet | a.get[k] = b.get[k]
 }
 
-pred Map.putIfAbsent( m' : Map, k, initial, r : Object ) {
+pred Map.putIfAbsent( m" : Map, k, initial, r : Object ) {
 	this.containsKey[k] 
 		implies r = this.get[k] 
-		else ( r=null and this.put[m',k,initial,null])
+		else ( r=null and this.put[m",k,initial,null])
 }
 
-pred Map.remove( m' : Map, k, v : Object, r : boolean ) {
+pred Map.remove( m" : Map, k, v : Object, r : boolean ) {
 	k -> v in this.entries 
-		implies ( m'.entries = this.entries - k -> v 
+		implies ( m".entries = this.entries - k -> v
 			and r = true ) 
 		else r=false
 }
 
-pred Map.replace( m' : Map, k, oldValue, newValue : Object, r : boolean ) {
-		this.put[m',k,newValue,oldValue] implies r = true else r = false
+pred Map.replace( m" : Map, k, oldValue, newValue : Object, r : boolean ) {
+		this.put[m",k,newValue,oldValue] implies r = true else r = false
 }
 
 /*
@@ -98,71 +98,71 @@ pred Map.replace( m' : Map, k, oldValue, newValue : Object, r : boolean ) {
  * currently mapped to some value.
  */
 
-pred Map.replace( m' : Map, k, v, r : Object ) {
-		this.containsKey[k] implies this.put[m',k,v,r] else r = null
+pred Map.replace( m" : Map, k, v, r : Object ) {
+		this.containsKey[k] implies this.put[m",k,v,r] else r = null
 }
 
 
 
 // Verifications
 
-pred Map.put'(m' : Map, k, v, r : Object ) {
+pred Map.put"(m" : Map, k, v, r : Object ) {
 
-	m'.containsKey[k]
-	m'.get[k] = v 
+	m".containsKey[k]
+	m".get[k] = v
 	this.get[k]  = r 
 
 	this.containsKey[k]
 		implies {
-			this.size = m'.size
+			this.size = m".size
 
 			r = null or r != null
 		} else {
-			this.size.plus[1] = m'.size
+			this.size.plus[1] = m".size
 			r = null
 		}
 }
 
-pred Map.clear'[ m' : Map ] {
-	m'.size = 0
+pred Map.clear"[ m" : Map ] {
+	m".size = 0
 	all k : Object | {
-		m'.get[k] = null
-		not m'.containsKey[k]
+		m".get[k] = null
+		not m".containsKey[k]
 	}
 }
 
-pred Map.remove'( m' : Map, k, r : Object) {
-	not m'.containsKey[k]
+pred Map.remove"( m" : Map, k, r : Object) {
+	not m".containsKey[k]
 
 	this.containsKey[k] implies {
 		this.get[k] = r
-		this.size.minus[1] = m'.size	
+		this.size.minus[1] = m".size
 	} else {
 		r = null
-		this.size = m'.size				
+		this.size = m".size
 	}
 }
 
-pred Map.putAll'( m', other : Map ) {
+pred Map.putAll"( m", other : Map ) {
 
-	this.keySet + other.keySet = m'.keySet
+	this.keySet + other.keySet = m".keySet
 
 	all k : this.keySet + other.keySet | {
 		let v = k in other.keySet 
 			implies other.get[k] 
 			else 		this.get[k] | {
-				m'.get[k] = v
+				m".get[k] = v
 			}
 	}
 }
 
 assert verify {
 
-	all m, m', other : Map, k, v, r : Object | {
-		m.put[m', k, v, r ] 		implies m.put'[m',k,v,r]
-		m.clear[m']          		implies m.clear'[m']
-		m.remove[m',k, r]				implies m.remove'[m',k,r]
-		m.putAll[m',other]			implies m.putAll'[m',other]
+	all m, m", other : Map, k, v, r : Object | {
+		m.put[m", k, v, r ] 		implies m.put"[m",k,v,r]
+		m.clear[m"]          		implies m.clear"[m"]
+		m.remove[m",k, r]				implies m.remove"[m",k,r]
+		m.putAll[m",other]			implies m.putAll"[m",other]
 	}
 
 }

--- a/models/java/javatypes_soundness.als
+++ b/models/java/javatypes_soundness.als
@@ -88,11 +88,11 @@ pred HasType [v: Value, t: Type] {
   v in Null or Subtype [v.type, t]
   }
 
-pred Subtype [t, t': Type] {
+pred Subtype [t, t": Type] {
   t in Class =>
      (let supers = (t & Class).*(Class<:xtends) |
-        t' in (supers + supers.implements.*(Interface<:xtends)))
-  t in Interface => t' in (t & Interface).*(Interface<:xtends)
+        t" in (supers + supers.implements.*(Interface<:xtends)))
+  t in Interface => t" in (t & Interface).*(Interface<:xtends)
   }
 
 pred TypeChecksSetter [stmt: Setter] {
@@ -101,24 +101,24 @@ pred TypeChecksSetter [stmt: Setter] {
   Subtype [stmt.rexpr.type, stmt.field.declType]
   }
 
-pred ExecuteSetter [s, s': State, stmt: Setter] {
+pred ExecuteSetter [s, s": State, stmt: Setter] {
   stmt.(rexpr+lexpr).subexprs & Variable in s.vars
-  s'.objects = s.objects and s'.vars = s.vars
+  s".objects = s.objects and s".vars = s.vars
   let rval = s.val [stmt.rexpr], lval = s.val [stmt.lexpr] {
     no lval & Null
-    s'.holds = s.holds ++ (lval.slot[stmt.field] -> rval)
+    s".holds = s.holds ++ (lval.slot[stmt.field] -> rval)
    }
   }
 
 assert TypeSoundness {
-  all s, s': State, stmt: Setter |
+  all s, s": State, stmt: Setter |
     {RuntimeTypesOK[s]
-    ExecuteSetter [s, s', stmt]
+    ExecuteSetter [s, s", stmt]
     TypeChecksSetter[stmt]
-    } => RuntimeTypesOK[s']
+    } => RuntimeTypesOK[s"]
   }
 
-fact {all o, o': Object | some o.slot[Field] & o'.slot[Field] => o = o'}
+fact {all o, o": Object | some o.slot[Field] & o".slot[Field] => o = o"}
 fact {all g: Getter | no g & g.^subexprs}
 
 fact ScopeFact {

--- a/models/logic/philosophers.als
+++ b/models/logic/philosophers.als
@@ -15,30 +15,30 @@ sig P {
 	right = next.@left
 }
 
-let update[table',settings'] = no table' or table'.setting=settings'
+let update[table",settings"] = no table" or table".setting=settings"
 
-let take[ philosopher, fork, table, table'] {
+let take[ philosopher, fork, table, table"] {
 	no table.setting.fork
-	table'.update[ table.setting + philosopher -> fork ]
+	table".update[ table.setting + philosopher -> fork ]
 }
 
-let eat[ philosopher, table,  table' ] {
+let eat[ philosopher, table,  table" ] {
 	let forks = table.setting[philosopher] {
 		# forks = 2
-		table'.update[ table.setting - philosopher->forks ]
+		table".update[ table.setting - philosopher->forks ]
 	}
 }
 
-let wait[p,table,tableOrNone'] = {
-	one tableOrNone'
-	tableOrNone'.setting = table.setting
+let wait[p,table,tableOrNone"] = {
+	one tableOrNone"
+	tableOrNone".setting = table.setting
 }
 
-pred step[ philosopher : P, table : Table, table' : lone Table ] {
-		philosopher.take[ philosopher.left, 	table, table' ]
-	or 	philosopher.take[ philosopher.right, 	table, table' ]
-	or	philosopher.eat[ 						table, table' ]
-	or  philosopher.wait[						table, table' ]
+pred step[ philosopher : P, table : Table, table" : lone Table ] {
+		philosopher.take[ philosopher.left, 	table, table" ]
+	or 	philosopher.take[ philosopher.right, 	table, table" ]
+	or	philosopher.eat[ 						table, table" ]
+	or  philosopher.wait[						table, table" ]
 
 }
 

--- a/models/transport/railway.als
+++ b/models/transport/railway.als
@@ -24,9 +24,9 @@ pred MayMove [g: GateState, x: TrainState, ts: set Train] {
   no ts.(x.on) & g.closed
   }
 
-pred TrainsMove [x, x': TrainState, ts: set Train] {
-  all t: ts | t.(x'.on) in t.(x.on).next
-  all t: Train - ts | t.(x'.on) = t.(x.on)
+pred TrainsMove [x, x": TrainState, ts: set Train] {
+  all t: ts | t.(x".on) in t.(x.on).next
+  all t: Train - ts | t.(x".on) = t.(x.on)
   }
 
 pred GatePolicy [g: GateState, x: TrainState] {
@@ -35,19 +35,19 @@ pred GatePolicy [g: GateState, x: TrainState] {
 }
 
 assert PolicyWorks {
-  all x, x': TrainState, g: GateState, ts: set Train |
+  all x, x": TrainState, g: GateState, ts: set Train |
     {MayMove [g, x, ts]
-    TrainsMove [x, x', ts]
+    TrainsMove [x, x", ts]
     Safe [x]
     GatePolicy [g, x]
-    } => Safe [x']
+    } => Safe [x"]
   }
 
 -- has counterexample in scope of 4
 check PolicyWorks for 2 Train, 1 GateState, 2 TrainState, 4 Seg expect 1
 
-pred TrainsMoveLegal [x, x': TrainState, g: GateState, ts: set Train] {
-  TrainsMove [x, x', ts]
+pred TrainsMoveLegal [x, x": TrainState, g: GateState, ts: set Train] {
+  TrainsMove [x, x", ts]
   MayMove [g, x, ts]
   GatePolicy [g, x]
   }

--- a/models/typography/paragraph-numbering.als
+++ b/models/typography/paragraph-numbering.als
@@ -83,14 +83,14 @@ pred Forest [s: State] {
     all x: Style | lone x.replaces & s.context
     }
 
-pred AddStyleToContext [s, s': State, style: Style] {
+pred AddStyleToContext [s, s": State, style: Style] {
     all x: style.^parents | some x.replaces & s.context
-    s'.context = s.context - style.replaces + style
+    s".context = s.context - style.replaces + style
     }
 
 assert PreserveForest {
-    all s,s': State, z: Style |
-        Forest[s] && AddStyleToContext [s,s',z] => Forest[s']
+    all s,s": State, z: Style |
+        Forest[s] && AddStyleToContext [s,s",z] => Forest[s"]
     }
 
 check PreserveForest for 4 expect 0
@@ -105,22 +105,22 @@ sig NumberedState extends State {
 fact {Style = NumberedStyle}
 fact {State = NumberedState}
 
-pred AddStyleToNumbering [s, s': State, style: Style] {
-    s'.value[style] = (style in s.context => s.value[style].next else style.initial)
-    s'.context = s.context - style.replaces + style
+pred AddStyleToNumbering [s, s": State, style: Style] {
+    s".value[style] = (style in s.context => s.value[style].next else style.initial)
+    s".context = s.context - style.replaces + style
     all x: Style - style |
-        s'.value[x] = (style in x.^parents => x.initial else s.value[x])
+        s".value[x] = (style in x.^parents => x.initial else s.value[x])
     }
 
-pred AddStyle [s, s': State, style: Style] {
-    AddStyleToContext [s,s',style]
-    AddStyleToNumbering [s,s',style]
+pred AddStyle [s, s": State, style: Style] {
+    AddStyleToContext [s,s",style]
+    AddStyleToNumbering [s,s",style]
     }
 
 assert AddNeverReduces {
-    all s,s': State, z: Style |
-        Forest[s] && AddStyle [s,s',z] =>
-            (all y: s'.context | s'.value[y] in s.value[y].*next)
+    all s,s": State, z: Style |
+        Forest[s] && AddStyle [s,s",z] =>
+            (all y: s".context | s".value[y] in s.value[y].*next)
     }
 
 check AddNeverReduces for 5 expect 1

--- a/models/webattack/webattack.md
+++ b/models/webattack/webattack.md
@@ -116,8 +116,8 @@ the cart. I.e. it _activates_ the cart. (Never realized you could hack in models
 
 ```alloy
 
-	pred login[ s, s' : lone State ] {
-		let 	browser = s'.browser, 
+	pred login[ s, s" : lone State ] {
+		let 	browser = s".browser,
 			userid = browser.userid,
 			password = browser.password {
 
@@ -126,13 +126,13 @@ the cart. I.e. it _activates_ the cart. (Never realized you could hack in models
 			no s.cart.userid
 			authenticate[ userid,password ] 
 
-			s'.action = LOGIN
-			s'.nextToken = s.nextToken.next
-			s'.stock = s.stock
-			s'.cart = s.cart + (s.nextToken->userid)
-			s'.token = s.nextToken
-			s'.bought = none	
-			s'.cookies = s.cookies + (browser->s.nextToken)
+			s".action = LOGIN
+			s".nextToken = s.nextToken.next
+			s".stock = s.stock
+			s".cart = s.cart + (s.nextToken->userid)
+			s".token = s.nextToken
+			s".bought = none
+			s".cookies = s.cookies + (browser->s.nextToken)
 		}
 	}
 ```
@@ -144,9 +144,9 @@ the sale in the corresponding cart.
 
 ```alloy
 
-	pred buy[ s, s' : State ] {
-		let 	item 	= s'.bought, 
-			tkn 	= s'.token {
+	pred buy[ s, s" : State ] {
+		let 	item 	= s".bought,
+			tkn 	= s".token {
 
 			some item
 			item in s.stock 
@@ -154,14 +154,14 @@ the sale in the corresponding cart.
 			one tkn
 			some s.cart[tkn]
 	
-			s'.action = BUY
-			s'.nextToken = s.nextToken
-			s'.stock = s.stock-item
-			s'.cart = s.cart + (tkn -> item)
-			s'.token = tkn
-			s'.bought = item
+			s".action = BUY
+			s".nextToken = s.nextToken
+			s".stock = s.stock-item
+			s".cart = s.cart + (tkn -> item)
+			s".token = tkn
+			s".bought = item
 	
-			s'.cookies = s.cookies
+			s".cookies = s.cookies
 		}
 	}
 ```
@@ -175,17 +175,17 @@ For `check` commands they are generally irrelevant.
 
 ```alloy
 
-	pred stutter[s, s' : State ] {
+	pred stutter[s, s" : State ] {
 
-		s'.action = STUTTER
-		s'.nextToken = s.nextToken
-		s'.stock = s.stock
-		s'.cart = s.cart
-		s'.browser = none
-		s'.token = none
-		s'.bought = none
+		s".action = STUTTER
+		s".nextToken = s.nextToken
+		s".stock = s.stock
+		s".cart = s.cart
+		s".browser = none
+		s".token = none
+		s".bought = none
 
-		s'.cookies = s.cookies
+		s".cookies = s.cookies
 	}		
 
 ```
@@ -233,13 +233,13 @@ That is, each action predicate is used to constrain State<sup>n</sup> -> State<s
 		no st/first.cookies
 		st/first.action = INIT
 
-		all s' : State - first, s : s'.prev {
+		all s" : State - first, s : s".prev {
 
-				login[s,s']
+				login[s,s"]
 			or 
-				buy[s,s']
+				buy[s,s"]
 			or
-				stutter[s,s']
+				stutter[s,s"]
 
 		}
 	}

--- a/puzzles/farmer-chicken-fox/farmer.als
+++ b/puzzles/farmer-chicken-fox/farmer.als
@@ -50,24 +50,24 @@ fact initialState {
  * Constrains at most one item to move from 'from' to 'to'.
  * Also constrains which objects get eaten.
  */
-pred crossRiver [from, from', to, to': set Object] {
+pred crossRiver [from, from", to, to": set Object] {
    // either the Farmer takes no items
-   (from' = from - Farmer - from'.eats and
-    to' = to + Farmer) or
+   (from" = from - Farmer - from".eats and
+    to" = to + Farmer) or
     // or the Farmer takes one item
     (one x : from - Farmer | {
-       from' = from - Farmer - x - from'.eats
-       to' = to + Farmer + x })
+       from" = from - Farmer - x - from".eats
+       to" = to + Farmer + x })
 }
 
 /**
  * crossRiver transitions between states
  */
 fact stateTransition {
-  all s: State, s': ord/next[s] {
+  all s: State, s": ord/next[s] {
     Farmer in s.near =>
-      crossRiver[s.near, s'.near, s.far, s'.far] else
-      crossRiver[s.far, s'.far, s.near, s'.near]
+      crossRiver[s.near, s".near, s.far, s".far] else
+      crossRiver[s.far, s".far, s.near, s".near]
   }
 }
 

--- a/puzzles/prisoner-room-visit/prisoner.als
+++ b/puzzles/prisoner-room-visit/prisoner.als
@@ -45,59 +45,59 @@ pred CurrentPlayerSetToNull {first.currentPrisoner = NULL}
 
 fact Init{TineSwichedSetToZero and CountSetToZero and SwitchesInBoolean and AnnouncedSetToFalse and CurrentPlayerSetToNull}
 
-pred NonCounterStep[game, game': State,p:Prisoner]{
+pred NonCounterStep[game, game": State,p:Prisoner]{
 	p in OtherPrisoner
-	game'.currentPrisoner = p
-	game'.announced = game.announced
-	game'.count = game.count
+	game".currentPrisoner = p
+	game".announced = game.announced
+	game".count = game.count
 	(game.announced= True =>
-		game'.SwitchesStatus = game.SwitchesStatus
-		and game'.timesSwitched = game.timesSwitched
+		game".SwitchesStatus = game.SwitchesStatus
+		and game".timesSwitched = game.timesSwitched
 	else
 		((game.SwitchesStatus[SwitcheA] = Down and p.(game.timesSwitched) <2) =>
-			SwitcheA.(game'.SwitchesStatus) = Up
-			and SwitcheB.(game'.SwitchesStatus) = SwitcheB.(game.SwitchesStatus)
-			and game'.timesSwitched = game.timesSwitched - p->p.(game.timesSwitched) + p->(p.(game.timesSwitched)+1)
+			SwitcheA.(game".SwitchesStatus) = Up
+			and SwitcheB.(game".SwitchesStatus) = SwitcheB.(game.SwitchesStatus)
+			and game".timesSwitched = game.timesSwitched - p->p.(game.timesSwitched) + p->(p.(game.timesSwitched)+1)
 		else
-			game'.timesSwitched = game.timesSwitched
-			and SwitcheA.(game'.SwitchesStatus) = SwitcheA.(game.SwitchesStatus)
+			game".timesSwitched = game.timesSwitched
+			and SwitcheA.(game".SwitchesStatus) = SwitcheA.(game.SwitchesStatus)
 			and (SwitcheB.(game.SwitchesStatus) = Up=>
-				SwitcheB.(game'.SwitchesStatus) = Down
+				SwitcheB.(game".SwitchesStatus) = Down
 			else
-				SwitcheB.(game'.SwitchesStatus) = Up)))
+				SwitcheB.(game".SwitchesStatus) = Up)))
 }
 
-pred CounterStep[game, game': State, p:Prisoner]{
+pred CounterStep[game, game": State, p:Prisoner]{
 	p = CounterPrisoner
-	game'.currentPrisoner = p
-	game'.timesSwitched = game.timesSwitched
+	game".currentPrisoner = p
+	game".timesSwitched = game.timesSwitched
 	(game.announced= True =>
-		game'.SwitchesStatus = game.SwitchesStatus
-		and game'.announced = game.announced
-		and game'.count =game.count
+		game".SwitchesStatus = game.SwitchesStatus
+		and game".announced = game.announced
+		and game".count =game.count
 	else
 		(SwitcheA.(game.SwitchesStatus) = Up =>
-			SwitcheA.(game'.SwitchesStatus) = Down
-			and SwitcheB.(game'.SwitchesStatus) = SwitcheB.(game.SwitchesStatus)
-			and game'.count =game.count +1
-			and (game'.count = 2.mul[(#Prisoner-1)] =>
-				game'.announced = True
+			SwitcheA.(game".SwitchesStatus) = Down
+			and SwitcheB.(game".SwitchesStatus) = SwitcheB.(game.SwitchesStatus)
+			and game".count =game.count +1
+			and (game".count = 2.mul[(#Prisoner-1)] =>
+				game".announced = True
 			else
-				game'.announced = game.announced)
+				game".announced = game.announced)
 		else
-			game'.count = game.count
-			and game'.announced = game.announced
-			and SwitcheA.(game'.SwitchesStatus) = SwitcheA.(game.SwitchesStatus)
+			game".count = game.count
+			and game".announced = game.announced
+			and SwitcheA.(game".SwitchesStatus) = SwitcheA.(game.SwitchesStatus)
 			and (SwitcheB.(game.SwitchesStatus) = Up=>
-				SwitcheB.(game'.SwitchesStatus) = Down
+				SwitcheB.(game".SwitchesStatus) = Down
 			else
-				SwitcheB.(game'.SwitchesStatus) = Up)))
+				SwitcheB.(game".SwitchesStatus) = Up)))
 }
 
 fact Steps{
-		all s: State, s': s.next {
-			(one p:OtherPrisoner | NonCounterStep[s, s',p])
-			 or (one p:CounterPrisoner | CounterStep[s, s',p])
+		all s: State, s": s.next {
+			(one p:OtherPrisoner | NonCounterStep[s, s",p])
+			 or (one p:CounterPrisoner | CounterStep[s, s",p])
 		}
 }
 
@@ -147,7 +147,7 @@ check CountInvariant for 3 Prisoner, 10 State
 pred AfterNonCounterPlayerEventaullyCounterPlayertEnterTheRoom{
 		all s: State|
 			((s.currentPrisoner in OtherPrisoner) => 
-				(some s': s.^next | s'.currentPrisoner = CounterPrisoner))
+				(some s": s.^next | s".currentPrisoner = CounterPrisoner))
 }
 
 pred PrisonerComesImmediatelyAfterCounter[s: State, p:OtherPrisoner]{ 
@@ -155,9 +155,9 @@ pred PrisonerComesImmediatelyAfterCounter[s: State, p:OtherPrisoner]{
 }
 
 pred Fairness {(all p:OtherPrisoner{ 
-			some s,s':State {s' in s.^next 
+			some s,s":State {s" in s.^next
 					and PrisonerComesImmediatelyAfterCounter[s,p] 
-					and PrisonerComesImmediatelyAfterCounter[s',p]
+					and PrisonerComesImmediatelyAfterCounter[s",p]
 			}
 		})
 		AfterNonCounterPlayerEventaullyCounterPlayertEnterTheRoom

--- a/puzzles/tower-hanoi/hanoi.als
+++ b/puzzles/tower-hanoi/hanoi.als
@@ -73,18 +73,18 @@ fun topDisc[st: State, stake: Stake]: lone Disc {
  * the "det" modifier above.  (It's important to use the "det" modifier
  * to tell the Alloy Analyzer that the function is in fact deterministic.)
  */
-pred Move [st: State, fromStake, toStake: Stake, s': State] {
+pred Move [st: State, fromStake, toStake: Stake, s": State] {
    let d = st.topDisc[fromStake] | {
       // all discs on toStake must be larger than d,
       // so that we can put d on top of them
       st.discsOnStake[toStake] in discs/nexts[d]
       // after, the fromStake has the discs it had before, minus d
-      s'.discsOnStake[fromStake] = st.discsOnStake[fromStake] - d
+      s".discsOnStake[fromStake] = st.discsOnStake[fromStake] - d
       // after, the toStake has the discs it had before, plus d
-      s'.discsOnStake[toStake] = st.discsOnStake[toStake] + d
+      s".discsOnStake[toStake] = st.discsOnStake[toStake] + d
       // the remaining stake afterwards has exactly the discs it had before
       let otherStake = Stake - fromStake - toStake |
-        s'.discsOnStake[otherStake] = st.discsOnStake[otherStake]
+        s".discsOnStake[otherStake] = st.discsOnStake[otherStake]
    }
 }
 

--- a/simple-models/books/birthday.als
+++ b/simple-models/books/birthday.als
@@ -27,12 +27,12 @@ sig Name {}
 sig Date {}
 sig BirthdayBook {known: set Name, date: known -> one Date}
 
-pred AddBirthday [bb, bb': BirthdayBook, n: Name, d: Date] {
-    bb'.date = bb.date ++ (n->d)
+pred AddBirthday [bb, bb": BirthdayBook, n: Name, d: Date] {
+    bb".date = bb.date ++ (n->d)
     }
 
-pred DelBirthday [bb, bb': BirthdayBook, n: Name] {
-    bb'.date = bb.date - (n->Date)
+pred DelBirthday [bb, bb": BirthdayBook, n: Name] {
+    bb".date = bb.date - (n->Date)
     }
 
 pred FindBirthday [bb: BirthdayBook, n: Name, d: lone Date] {
@@ -48,8 +48,8 @@ pred InitBirthdayBook [bb: BirthdayBook] {
     }
 
 assert AddWorks {
-    all bb, bb': BirthdayBook, n: Name, d: Date, d': lone Date |
-        AddBirthday [bb,bb',n,d] && FindBirthday [bb',n,d'] => d = d'
+    all bb, bb": BirthdayBook, n: Name, d: Date, d": lone Date |
+        AddBirthday [bb,bb",n,d] && FindBirthday [bb",n,d"] => d = d"
     }
 
 assert DelIsUndo {

--- a/simple-models/state-machine/flip-flop.als
+++ b/simple-models/state-machine/flip-flop.als
@@ -25,10 +25,10 @@ fact {
   first.state = On
   no last.event
 
-  all t : Trace - last, t' : t.next {
+  all t : Trace - last, t" : t.next {
     some e : Event {
       t.event = e 
-      t'.state = transitions[t.state][t.event]		
+      t".state = transitions[t.state][t.event]
     }
   }
 }

--- a/simple-models/state-machine/reset-flipflop-with-enable.als
+++ b/simple-models/state-machine/reset-flipflop-with-enable.als
@@ -20,10 +20,10 @@ fact {
 	first.state = On
 	no last.event	
 
-	all t' : Trace - first, t : t'.prev {
+	all t" : Trace - first, t : t".prev {
 		some e : Event | 
 					t.event = e 
-			and t'.state = transitions[t.state][t.event]		
+			and t".state = transitions[t.state][t.event]
 	}
 }
 

--- a/software-abstractions-book/appendixA/addressBook2.als
+++ b/software-abstractions-book/appendixA/addressBook2.als
@@ -14,12 +14,12 @@ pred inv [b: Book] {
 		}
 	}
 
-pred add [b, b': Book, n: Name, t: Name+Addr] {
-	b'.addr = b.addr + n->t
+pred add [b, b": Book, n: Name, t: Name+Addr] {
+	b".addr = b.addr + n->t
 	}
 
-pred del [b, b': Book, n: Name, t: Name+Addr] {
-	b'.addr = b.addr - n->t
+pred del [b, b": Book, n: Name, t: Name+Addr] {
+	b".addr = b.addr - n->t
 	}
 
 fun lookup [b: Book, n: Name] : set Addr {

--- a/software-abstractions-book/appendixE/p300-hotel.als
+++ b/software-abstractions-book/appendixE/p300-hotel.als
@@ -26,25 +26,25 @@ pred init [t: Time] {
 	no issued.t and no cards.t ------ bug! (see page 303)
 	}
 
-pred checkin [t,t': Time, r: Room, g: Guest] {
+pred checkin [t,t": Time, r: Room, g: Guest] {
 	some c: Card {
 		c.fst = r.(Desk.prev.t)
 		c.snd not in Desk.issued.t
-		cards.t' = cards.t + g->c ------------- bug! (see page 306)
-		Desk.issued.t' = Desk.issued.t + c.snd
-		Desk.prev.t' = Desk.prev.t ++ r->c.snd
+		cards.t" = cards.t + g->c ------------- bug! (see page 306)
+		Desk.issued.t" = Desk.issued.t + c.snd
+		Desk.prev.t" = Desk.prev.t ++ r->c.snd
 		}
-	key.t = key.t'
+	key.t = key.t"
 	}
 
-pred enter [t,t': Time, r: Room, g: Guest] {
+pred enter [t,t": Time, r: Room, g: Guest] {
 	some c: g.cards.t |
 		let k = r.key.t {
-			c.snd = k and key.t' = key.t
-			or c.fst = k and key.t' = key.t ++ r->c.snd
+			c.snd = k and key.t" = key.t
+			or c.fst = k and key.t" = key.t ++ r->c.snd
 			}
-	issued.t = issued.t' and (Desk<:prev).t = prev.t'
-	cards.t = cards.t'
+	issued.t = issued.t" and (Desk<:prev).t = prev.t"
+	cards.t = cards.t"
 	}
 
 fact Traces {
@@ -54,10 +54,10 @@ fact Traces {
 	}
 
 assert NoIntruder {
-	no t1: Time, g: Guest, g': Guest-g, r: Room |
+	no t1: Time, g: Guest, g": Guest-g, r: Room |
 		let t2=t1.next, t3=t2.next, t4=t3.next {
 			enter [t1, t2, r, g]
-			enter [t2, t3, r, g']
+			enter [t2, t3, r, g"]
 			enter [t3, t4, r, g]
 		}
 	}

--- a/software-abstractions-book/appendixE/p303-hotel.als
+++ b/software-abstractions-book/appendixE/p303-hotel.als
@@ -26,25 +26,25 @@ pred init [t: Time] {
 	Desk.issued.t = Room.key.t and no cards.t
 	}
 
-pred checkin [t,t': Time, r: Room, g: Guest] {
+pred checkin [t,t": Time, r: Room, g: Guest] {
 	some c: Card {
 		c.fst = r.(Desk.prev.t)
 		c.snd not in Desk.issued.t
-		cards.t' = cards.t + g->c ------------- bug! (see page 306)
-		Desk.issued.t' = Desk.issued.t + c.snd
-		Desk.prev.t' = Desk.prev.t ++ r->c.snd
+		cards.t" = cards.t + g->c ------------- bug! (see page 306)
+		Desk.issued.t" = Desk.issued.t + c.snd
+		Desk.prev.t" = Desk.prev.t ++ r->c.snd
 		}
-	key.t = key.t'
+	key.t = key.t"
 	}
 
-pred enter [t,t': Time, r: Room, g: Guest] {
+pred enter [t,t": Time, r: Room, g: Guest] {
 	some c: g.cards.t |
 		let k = r.key.t {
-			c.snd = k and key.t' = key.t
-			or c.fst = k and key.t' = key.t ++ r->c.snd
+			c.snd = k and key.t" = key.t
+			or c.fst = k and key.t" = key.t ++ r->c.snd
 			}
-	issued.t = issued.t' and (Desk<:prev).t = prev.t'
-	cards.t = cards.t'
+	issued.t = issued.t" and (Desk<:prev).t = prev.t"
+	cards.t = cards.t"
 	}
 
 fact Traces {
@@ -54,10 +54,10 @@ fact Traces {
 	}
 
 assert NoIntruder {
-	no t1: Time, g: Guest, g': Guest-g, r: Room |
+	no t1: Time, g: Guest, g": Guest-g, r: Room |
 		let t2=t1.next, t3=t2.next, t4=t3.next {
 			enter [t1, t2, r, g]
-			enter [t2, t3, r, g']
+			enter [t2, t3, r, g"]
 			enter [t3, t4, r, g]
 		}
 	}

--- a/software-abstractions-book/appendixE/p306-hotel.als
+++ b/software-abstractions-book/appendixE/p306-hotel.als
@@ -26,25 +26,25 @@ pred init [t: Time] {
 	Desk.issued.t = Room.key.t and no cards.t
 	}
 
-pred checkin [t,t': Time, r: Room, g: Guest] {
+pred checkin [t,t": Time, r: Room, g: Guest] {
 	some c: Card {
 		c.fst = r.(Desk.prev.t)
 		c.snd not in Desk.issued.t
-		cards.t' = cards.t ++ g->c
-		Desk.issued.t' = Desk.issued.t + c.snd
-		Desk.prev.t' = Desk.prev.t ++ r->c.snd
+		cards.t" = cards.t ++ g->c
+		Desk.issued.t" = Desk.issued.t + c.snd
+		Desk.prev.t" = Desk.prev.t ++ r->c.snd
 		}
-	key.t = key.t'
+	key.t = key.t"
 	}
 
-pred enter [t,t': Time, r: Room, g: Guest] {
+pred enter [t,t": Time, r: Room, g: Guest] {
 	some c: g.cards.t |
 		let k = r.key.t {
-			c.snd = k and key.t' = key.t
-			or c.fst = k and key.t' = key.t ++ r->c.snd
+			c.snd = k and key.t" = key.t
+			or c.fst = k and key.t" = key.t ++ r->c.snd
 			}
-	issued.t = issued.t' and (Desk<:prev).t = prev.t'
-	cards.t = cards.t'
+	issued.t = issued.t" and (Desk<:prev).t = prev.t"
+	cards.t = cards.t"
 	}
 
 fact Traces {
@@ -54,10 +54,10 @@ fact Traces {
 	}
 
 assert NoIntruder {
-	no t1: Time, g: Guest, g': Guest-g, r: Room |
+	no t1: Time, g: Guest, g": Guest-g, r: Room |
 		let t2=t1.next, t3=t2.next, t4=t3.next {
 			enter [t1, t2, r, g]
-			enter [t2, t3, r, g']
+			enter [t2, t3, r, g"]
 			enter [t3, t4, r, g]
 		}
 	}

--- a/software-abstractions-book/chapter2/addressBook1e.als
+++ b/software-abstractions-book/chapter2/addressBook1e.als
@@ -6,8 +6,8 @@ sig Book {
 	addr: Name -> lone Addr
 }
 
-pred add [b, b': Book, n: Name, a: Addr] {
-	b'.addr = b.addr + n->a
+pred add [b, b": Book, n: Name, a: Addr] {
+	b".addr = b.addr + n->a
 }
 
 // This command generates an instance similar to Fig 2.4

--- a/software-abstractions-book/chapter2/addressBook1f.als
+++ b/software-abstractions-book/chapter2/addressBook1f.als
@@ -6,13 +6,13 @@ sig Book {
 	addr: Name -> lone Addr
 }
 
-pred add [b, b': Book, n: Name, a: Addr] {
-	b'.addr = b.addr + n->a
+pred add [b, b": Book, n: Name, a: Addr] {
+	b".addr = b.addr + n->a
 }
 
-pred showAdd [b, b': Book, n: Name, a: Addr] {
-	add [b, b', n, a]
-	#Name.(b'.addr) > 1
+pred showAdd [b, b": Book, n: Name, a: Addr] {
+	add [b, b", n, a]
+	#Name.(b".addr) > 1
 }
 
 // This command generates an instance similar to Fig 2.5

--- a/software-abstractions-book/chapter2/addressBook1g.als
+++ b/software-abstractions-book/chapter2/addressBook1g.als
@@ -6,12 +6,12 @@ sig Book {
 	addr: Name -> lone Addr
 }
 
-pred add [b, b': Book, n: Name, a: Addr] {
-	b'.addr = b.addr + n->a
+pred add [b, b": Book, n: Name, a: Addr] {
+	b".addr = b.addr + n->a
 }
 
-pred del [b, b': Book, n: Name] {
-	b'.addr = b.addr - n->Addr
+pred del [b, b": Book, n: Name] {
+	b".addr = b.addr - n->Addr
 }
 
 fun lookup [b: Book, n: Name] : set Addr {
@@ -19,10 +19,10 @@ fun lookup [b: Book, n: Name] : set Addr {
 }
 
 assert delUndoesAdd {
-	all b, b', b'': Book, n: Name, a: Addr |
-		add [b, b', n, a] and del [b', b'', n]
+	all b, b", b"": Book, n: Name, a: Addr |
+		add [b, b", n, a] and del [b", b"", n]
 		implies
-		b.addr = b''.addr
+		b.addr = b"".addr
 }
 
 // This command generates an instance similar to Fig 2.6

--- a/software-abstractions-book/chapter2/addressBook1h.als
+++ b/software-abstractions-book/chapter2/addressBook1h.als
@@ -12,43 +12,43 @@ pred show [b: Book] {
 }
 run show for 3 but 1 Book
 
-pred add [b, b': Book, n: Name, a: Addr] {
-	b'.addr = b.addr + n->a
+pred add [b, b": Book, n: Name, a: Addr] {
+	b".addr = b.addr + n->a
 }
 
-pred del [b, b': Book, n: Name] {
-	b'.addr = b.addr - n->Addr
+pred del [b, b": Book, n: Name] {
+	b".addr = b.addr - n->Addr
 }
 
 fun lookup [b: Book, n: Name] : set Addr {
 	n.(b.addr)
 }
 
-pred showAdd [b, b': Book, n: Name, a: Addr] {
-	add [b, b', n, a]
-	#Name.(b'.addr) > 1
+pred showAdd [b, b": Book, n: Name, a: Addr] {
+	add [b, b", n, a]
+	#Name.(b".addr) > 1
 }
 run showAdd for 3 but 2 Book
 
 assert delUndoesAdd {
-	all b, b', b'': Book, n: Name, a: Addr |
-		no n.(b.addr) and add [b, b', n, a] and del [b', b'', n]
+	all b, b", b"": Book, n: Name, a: Addr |
+		no n.(b.addr) and add [b, b", n, a] and del [b", b"", n]
 		implies
-		b.addr = b''.addr
+		b.addr = b"".addr
 }
 
 assert addIdempotent {
-	all b, b', b'': Book, n: Name, a: Addr |
-		add [b, b', n, a] and add [b', b'', n, a]
+	all b, b", b"": Book, n: Name, a: Addr |
+		add [b, b", n, a] and add [b", b"", n, a]
 		implies
-		b'.addr = b''.addr
+		b".addr = b"".addr
 }
 
 assert addLocal {
-	all b, b': Book, n, n': Name, a: Addr |
-		add [b, b', n, a] and n != n'
+	all b, b": Book, n, n": Name, a: Addr |
+		add [b, b", n, a] and n != n"
 		implies
-		lookup [b, n'] = lookup [b', n']
+		lookup [b, n"] = lookup [b", n"]
 }
 
 // This command should not find any counterexample.

--- a/software-abstractions-book/chapter2/addressBook2e.als
+++ b/software-abstractions-book/chapter2/addressBook2e.als
@@ -14,35 +14,35 @@ sig Book {
 	all a: Alias | lone a.addr
 }
 
-pred add [b, b': Book, n: Name, t: Target] { b'.addr = b.addr + n->t }
-pred del [b, b': Book, n: Name, t: Target] { b'.addr = b.addr - n->t }
+pred add [b, b": Book, n: Name, t: Target] { b".addr = b.addr + n->t }
+pred del [b, b": Book, n: Name, t: Target] { b".addr = b.addr - n->t }
 fun lookup [b: Book, n: Name] : set Addr { n.^(b.addr) & Addr }
 
 assert delUndoesAdd {
-	all b, b', b'': Book, n: Name, t: Target |
-		no n.(b.addr) and add [b, b', n, t] and del [b', b'', n, t]
+	all b, b", b"": Book, n: Name, t: Target |
+		no n.(b.addr) and add [b, b", n, t] and del [b", b"", n, t]
 		implies
-		b.addr = b''.addr
+		b.addr = b"".addr
 }
 
 // This should not find any counterexample.
 check delUndoesAdd for 3
 
 assert addIdempotent {
-	all b, b', b'': Book, n: Name, t: Target |
-		add [b, b', n, t] and add [b', b'', n, t]
+	all b, b", b"": Book, n: Name, t: Target |
+		add [b, b", n, t] and add [b", b"", n, t]
 		implies
-		b'.addr = b''.addr
+		b".addr = b"".addr
 }
 
 // This should not find any counterexample.
 check addIdempotent for 3
 
 assert addLocal {
-	all b, b': Book, n, n': Name, t: Target |
-		add [b, b', n, t] and n != n'
+	all b, b": Book, n, n": Name, t: Target |
+		add [b, b", n, t] and n != n"
 		implies
-		lookup [b, n'] = lookup [b', n']
+		lookup [b, n"] = lookup [b", n"]
 }
 
 // This shows a counterexample similar to Fig 2.13

--- a/software-abstractions-book/chapter2/addressBook3a.als
+++ b/software-abstractions-book/chapter2/addressBook3a.als
@@ -16,8 +16,8 @@ sig Book {
 	all a: Alias | lone a.addr
 }
 
-pred add [b, b': Book, n: Name, t: Target] { b'.addr = b.addr + n->t }
-pred del [b, b': Book, n: Name, t: Target] { b'.addr = b.addr - n->t }
+pred add [b, b": Book, n: Name, t: Target] { b".addr = b.addr + n->t }
+pred del [b, b": Book, n: Name, t: Target] { b".addr = b.addr - n->t }
 fun lookup [b: Book, n: Name] : set Addr { n.^(b.addr) & Addr }
 
 pred init [b: Book]  { no b.addr }
@@ -25,9 +25,9 @@ pred init [b: Book]  { no b.addr }
 fact traces {
 	init [first]
 	all b: Book-last |
-	  let b' = b.next |
+	  let b" = b.next |
 	    some n: Name, t: Target |
-	      add [b, b', n, t] or del [b, b', n, t]
+	      add [b, b", n, t] or del [b, b", n, t]
 }
 
 ------------------------------------------------------

--- a/software-abstractions-book/chapter2/addressBook3b.als
+++ b/software-abstractions-book/chapter2/addressBook3b.als
@@ -16,8 +16,8 @@ sig Book {
 	all a: Alias | lone a.addr
 }
 
-pred add [b, b': Book, n: Name, t: Target] { b'.addr = b.addr + n->t }
-pred del [b, b': Book, n: Name, t: Target] { b'.addr = b.addr - n->t }
+pred add [b, b": Book, n: Name, t: Target] { b".addr = b.addr + n->t }
+pred del [b, b": Book, n: Name, t: Target] { b".addr = b.addr - n->t }
 fun lookup [b: Book, n: Name] : set Addr { n.^(b.addr) & Addr }
 
 pred init [b: Book]  { no b.addr }
@@ -25,18 +25,18 @@ pred init [b: Book]  { no b.addr }
 fact traces {
 	init [first]
 	all b: Book-last |
-	  let b' = b.next |
+	  let b" = b.next |
 	    some n: Name, t: Target |
-	      add [b, b', n, t] or del [b, b', n, t]
+	      add [b, b", n, t] or del [b, b", n, t]
 }
 
 ------------------------------------------------------
 
 assert delUndoesAdd {
-	all b, b', b'': Book, n: Name, t: Target |
-		no n.(b.addr) and add [b, b', n, t] and del [b', b'', n, t]
+	all b, b", b"": Book, n: Name, t: Target |
+		no n.(b.addr) and add [b, b", n, t] and del [b", b"", n, t]
 		implies
-		b.addr = b''.addr
+		b.addr = b"".addr
 }
 
 // This should not find any counterexample.
@@ -45,10 +45,10 @@ check delUndoesAdd for 3
 ------------------------------------------------------
 
 assert addIdempotent {
-	all b, b', b'': Book, n: Name, t: Target |
-		add [b, b', n, t] and add [b', b'', n, t]
+	all b, b", b"": Book, n: Name, t: Target |
+		add [b, b", n, t] and add [b", b"", n, t]
 		implies
-		b'.addr = b''.addr
+		b".addr = b"".addr
 }
 
 // This should not find any counterexample.
@@ -57,10 +57,10 @@ check addIdempotent for 3
 ------------------------------------------------------
 
 assert addLocal {
-	all b, b': Book, n, n': Name, t: Target |
-		add [b, b', n, t] and n != n'
+	all b, b": Book, n, n": Name, t: Target |
+		add [b, b", n, t] and n != n"
 		implies
-		lookup [b, n'] = lookup [b', n']
+		lookup [b, n"] = lookup [b", n"]
 }
 
 // This should not find any counterexample.

--- a/software-abstractions-book/chapter2/addressBook3c.als
+++ b/software-abstractions-book/chapter2/addressBook3c.als
@@ -16,12 +16,12 @@ sig Book {
 	all a: Alias | lone a.addr
 }
 
-pred add [b, b': Book, n: Name, t: Target] {
+pred add [b, b": Book, n: Name, t: Target] {
 	t in Addr or some lookup [b, Name&t]
-	b'.addr = b.addr + n->t
+	b".addr = b.addr + n->t
 }
 
-pred del [b, b': Book, n: Name, t: Target] { b'.addr = b.addr - n->t }
+pred del [b, b": Book, n: Name, t: Target] { b".addr = b.addr - n->t }
 
 fun lookup [b: Book, n: Name] : set Addr { n.^(b.addr) & Addr }
 
@@ -30,18 +30,18 @@ pred init [b: Book]  { no b.addr }
 fact traces {
 	init [first]
 	all b: Book-last |
-	  let b' = b.next |
+	  let b" = b.next |
 	    some n: Name, t: Target |
-	      add [b, b', n, t] or del [b, b', n, t]
+	      add [b, b", n, t] or del [b, b", n, t]
 }
 
 ------------------------------------------------------
 
 assert delUndoesAdd {
-	all b, b', b'': Book, n: Name, t: Target |
-		no n.(b.addr) and add [b, b', n, t] and del [b', b'', n, t]
+	all b, b", b"": Book, n: Name, t: Target |
+		no n.(b.addr) and add [b, b", n, t] and del [b", b"", n, t]
 		implies
-		b.addr = b''.addr
+		b.addr = b"".addr
 }
 
 // This should not find any counterexample.
@@ -50,10 +50,10 @@ check delUndoesAdd for 3
 ------------------------------------------------------
 
 assert addIdempotent {
-	all b, b', b'': Book, n: Name, t: Target |
-		add [b, b', n, t] and add [b', b'', n, t]
+	all b, b", b"": Book, n: Name, t: Target |
+		add [b, b", n, t] and add [b", b"", n, t]
 		implies
-		b'.addr = b''.addr
+		b".addr = b"".addr
 }
 
 // This should not find any counterexample.
@@ -62,10 +62,10 @@ check addIdempotent for 3
 ------------------------------------------------------
 
 assert addLocal {
-	all b, b': Book, n, n': Name, t: Target |
-		add [b, b', n, t] and n != n'
+	all b, b": Book, n, n": Name, t: Target |
+		add [b, b", n, t] and n != n"
 		implies
-		lookup [b, n'] = lookup [b', n']
+		lookup [b, n"] = lookup [b", n"]
 }
 
 // This should not find any counterexample.

--- a/software-abstractions-book/chapter2/addressBook3d.als
+++ b/software-abstractions-book/chapter2/addressBook3d.als
@@ -16,14 +16,14 @@ sig Book {
 	all a: Alias | lone a.addr
 }
 
-pred add [b, b': Book, n: Name, t: Target] {
+pred add [b, b": Book, n: Name, t: Target] {
 	t in Addr or some lookup [b, Name&t]
-	b'.addr = b.addr + n->t
+	b".addr = b.addr + n->t
 }
 
-pred del [b, b': Book, n: Name, t: Target] {
+pred del [b, b": Book, n: Name, t: Target] {
 	no b.addr.n or some n.(b.addr) - t
-	b'.addr = b.addr - n->t
+	b".addr = b.addr - n->t
 }
 
 fun lookup [b: Book, n: Name] : set Addr { n.^(b.addr) & Addr }
@@ -33,18 +33,18 @@ pred init [b: Book]  { no b.addr }
 fact traces {
 	init [first]
 	all b: Book-last |
-	  let b' = b.next |
+	  let b" = b.next |
 	    some n: Name, t: Target |
-	      add [b, b', n, t] or del [b, b', n, t]
+	      add [b, b", n, t] or del [b, b", n, t]
 }
 
 ------------------------------------------------------
 
 assert delUndoesAdd {
-	all b, b', b'': Book, n: Name, t: Target |
-		no n.(b.addr) and add [b, b', n, t] and del [b', b'', n, t]
+	all b, b", b"": Book, n: Name, t: Target |
+		no n.(b.addr) and add [b, b", n, t] and del [b", b"", n, t]
 		implies
-		b.addr = b''.addr
+		b.addr = b"".addr
 }
 
 // This should not find any counterexample.
@@ -53,10 +53,10 @@ check delUndoesAdd for 3
 ------------------------------------------------------
 
 assert addIdempotent {
-	all b, b', b'': Book, n: Name, t: Target |
-		add [b, b', n, t] and add [b', b'', n, t]
+	all b, b", b"": Book, n: Name, t: Target |
+		add [b, b", n, t] and add [b", b"", n, t]
 		implies
-		b'.addr = b''.addr
+		b".addr = b"".addr
 }
 
 // This should not find any counterexample.
@@ -65,10 +65,10 @@ check addIdempotent for 3
 ------------------------------------------------------
 
 assert addLocal {
-	all b, b': Book, n, n': Name, t: Target |
-		add [b, b', n, t] and n != n'
+	all b, b": Book, n, n": Name, t: Target |
+		add [b, b", n, t] and n != n"
 		implies
-		lookup [b, n'] = lookup [b', n']
+		lookup [b, n"] = lookup [b", n"]
 }
 
 // This should not find any counterexample.

--- a/software-abstractions-book/chapter4/lights.als
+++ b/software-abstractions-book/chapter4/lights.als
@@ -18,18 +18,18 @@ pred mostlyRed [s: LightState, j: Junction] {
 	lone j.lights - redLights[s]
 	}
 
-pred trans [s, s': LightState, j: Junction] {
-	lone x: j.lights | s.color[x] != s'.color[x]
+pred trans [s, s": LightState, j: Junction] {
+	lone x: j.lights | s.color[x] != s".color[x]
 	all x: j.lights |
-		let step = s.color[x] -> s'.color[x] {
+		let step = s.color[x] -> s".color[x] {
 			step in colorSequence
 			step in Red->(Color-Red) => j.lights in redLights[s]
 		}
 	}
 
 assert Safe {
-	all s, s': LightState, j: Junction |
-		mostlyRed [s, j] and trans [s, s', j] => mostlyRed [s', j]
+	all s, s": LightState, j: Junction |
+		mostlyRed [s, j] and trans [s, s", j] => mostlyRed [s", j]
 	}
 
 check Safe for 3 but 1 Junction

--- a/software-abstractions-book/chapter5/addressBook.als
+++ b/software-abstractions-book/chapter5/addressBook.als
@@ -8,8 +8,8 @@ sig Book {addr: Name -> Target}
 
 fact Acyclic {all b: Book | no n: Name | n in n.^(b.addr)}
 
-pred add [b, b': Book, n: Name, t: Target] {
-	b'.addr = b.addr + n -> t
+pred add [b, b": Book, n: Name, t: Target] {
+	b".addr = b.addr + n -> t
 	}
 
 // This command should produce an instance similar to Fig 5.2
@@ -18,8 +18,8 @@ run add for 3 but 2 Book
 fun lookup [b: Book, n: Name]: set Addr {n.^(b.addr) & Addr}
 
 assert addLocal {
-	all b,b': Book, n,n': Name, t: Target |
-		add [b,b',n,t] and n != n' => lookup [b,n'] = lookup [b',n']
+	all b,b": Book, n,n": Name, t: Target |
+		add [b,b",n,t] and n != n" => lookup [b,n"] = lookup [b",n"]
 	}
 
 // This command should produce a counterexample similar to Fig 5.3

--- a/software-abstractions-book/chapter5/lists.als
+++ b/software-abstractions-book/chapter5/lists.als
@@ -11,7 +11,7 @@ sig NonEmptyList extends List {
 
 fact ListGenerator {
 	all list: List, e: Element |
-		some list': List | list'.rest = list and list'.element = e
+		some list": List | list".rest = list and list".element = e
 	}
 
 assert FalseAssertion {

--- a/software-abstractions-book/chapter5/sets2.als
+++ b/software-abstractions-book/chapter5/sets2.als
@@ -14,7 +14,7 @@ assert Closed {
 
 fact SetGenerator {
 	some s: Set | no s.elements
-	all s: Set, e: Element | some s': Set | s'.elements = s.elements + e
+	all s: Set, e: Element | some s": Set | s".elements = s.elements + e
 	}
 
 // This check should not produce a counterexample

--- a/software-abstractions-book/chapter6/hotel1.als
+++ b/software-abstractions-book/chapter6/hotel1.als
@@ -35,66 +35,66 @@ pred init [t: Time] {
 	all r: Room | FrontDesk.lastKey.t [r] = r.currentKey.t
 	}
 
-pred entry [t, t': Time, g: Guest, r: Room, k: Key] {
+pred entry [t, t": Time, g: Guest, r: Room, k: Key] {
 	k in g.keys.t
 	let ck = r.currentKey |
-		(k = ck.t and ck.t' = ck.t) or 
-		(k = nextKey[ck.t, r.keys] and ck.t' = k)
-	noRoomChangeExcept [t, t', r]
-	noGuestChangeExcept [t, t', none]
-	noFrontDeskChange [t, t']
+		(k = ck.t and ck.t" = ck.t) or
+		(k = nextKey[ck.t, r.keys] and ck.t" = k)
+	noRoomChangeExcept [t, t", r]
+	noGuestChangeExcept [t, t", none]
+	noFrontDeskChange [t, t"]
 	}
 
-pred noFrontDeskChange [t, t': Time] {
-	FrontDesk.lastKey.t = FrontDesk.lastKey.t'
-	FrontDesk.occupant.t = FrontDesk.occupant.t'
+pred noFrontDeskChange [t, t": Time] {
+	FrontDesk.lastKey.t = FrontDesk.lastKey.t"
+	FrontDesk.occupant.t = FrontDesk.occupant.t"
 	}
 
-pred noRoomChangeExcept [t, t': Time, rs: set Room] {
-	all r: Room - rs | r.currentKey.t = r.currentKey.t'
+pred noRoomChangeExcept [t, t": Time, rs: set Room] {
+	all r: Room - rs | r.currentKey.t = r.currentKey.t"
 	}
 	
-pred noGuestChangeExcept [t, t': Time, gs: set Guest] {
-	all g: Guest - gs | g.keys.t = g.keys.t'
+pred noGuestChangeExcept [t, t": Time, gs: set Guest] {
+	all g: Guest - gs | g.keys.t = g.keys.t"
 	}
 
-pred checkout [t, t': Time, g: Guest] {
+pred checkout [t, t": Time, g: Guest] {
 	let occ = FrontDesk.occupant {
 		some occ.t.g
-		occ.t' = occ.t - Room ->g
+		occ.t" = occ.t - Room ->g
 		}
-	FrontDesk.lastKey.t = FrontDesk.lastKey.t'
-	noRoomChangeExcept [t, t', none]
-	noGuestChangeExcept [t, t', none]
+	FrontDesk.lastKey.t = FrontDesk.lastKey.t"
+	noRoomChangeExcept [t, t", none]
+	noGuestChangeExcept [t, t", none]
 	}
 
-pred checkin [t, t': Time, g: Guest, r: Room, k: Key] {
-	g.keys.t' = g.keys.t + k
+pred checkin [t, t": Time, g: Guest, r: Room, k: Key] {
+	g.keys.t" = g.keys.t + k
 	let occ = FrontDesk.occupant {
 		no occ.t [r]
-		occ.t' = occ.t + r -> g
+		occ.t" = occ.t + r -> g
 		}
 	let lk = FrontDesk.lastKey {
-		lk.t' = lk.t ++ r -> k
+		lk.t" = lk.t ++ r -> k
 		k = nextKey [lk.t [r], r.keys]
 		}
-	noRoomChangeExcept [t, t', none]
-	noGuestChangeExcept [t, t', g]
+	noRoomChangeExcept [t, t", none]
+	noGuestChangeExcept [t, t", g]
 	}
 
 fact traces {
 	init [first]
-	all t: Time-last | let t' = t.next |
+	all t: Time-last | let t" = t.next |
 		some g: Guest, r: Room, k: Key |
-			entry [t, t', g, r, k]
-			or checkin [t, t', g, r, k]
-			or checkout [t, t', g]
+			entry [t, t", g, r, k]
+			or checkin [t, t", g, r, k]
+			or checkout [t, t", g]
 	}
 
 assert NoBadEntry {
 	all t: Time, r: Room, g: Guest, k: Key |
-		let t' = t.next, o = FrontDesk.occupant.t[r] | 
-			entry [t, t', g, r, k] and some o => g in o
+		let t" = t.next, o = FrontDesk.occupant.t[r] |
+			entry [t, t", g, r, k] and some o => g in o
 	}
 
 // This generates a counterexample similar to Fig 6.6

--- a/software-abstractions-book/chapter6/hotel2.als
+++ b/software-abstractions-book/chapter6/hotel2.als
@@ -35,72 +35,72 @@ pred init [t: Time] {
 	all r: Room | FrontDesk.lastKey.t [r] = r.currentKey.t
 	}
 
-pred entry [t, t': Time, g: Guest, r: Room, k: Key] {
+pred entry [t, t": Time, g: Guest, r: Room, k: Key] {
 	k in g.keys.t
 	let ck = r.currentKey |
-		(k = ck.t and ck.t' = ck.t) or 
-		(k = nextKey[ck.t, r.keys] and ck.t' = k)
-	noRoomChangeExcept [t, t', r]
-	noGuestChangeExcept [t, t', none]
-	noFrontDeskChange [t, t']
+		(k = ck.t and ck.t" = ck.t) or
+		(k = nextKey[ck.t, r.keys] and ck.t" = k)
+	noRoomChangeExcept [t, t", r]
+	noGuestChangeExcept [t, t", none]
+	noFrontDeskChange [t, t"]
 	}
 
-pred noFrontDeskChange [t, t': Time] {
-	FrontDesk.lastKey.t = FrontDesk.lastKey.t'
-	FrontDesk.occupant.t = FrontDesk.occupant.t'
+pred noFrontDeskChange [t, t": Time] {
+	FrontDesk.lastKey.t = FrontDesk.lastKey.t"
+	FrontDesk.occupant.t = FrontDesk.occupant.t"
 	}
 
-pred noRoomChangeExcept [t, t': Time, rs: set Room] {
-	all r: Room - rs | r.currentKey.t = r.currentKey.t'
+pred noRoomChangeExcept [t, t": Time, rs: set Room] {
+	all r: Room - rs | r.currentKey.t = r.currentKey.t"
 	}
 	
-pred noGuestChangeExcept [t, t': Time, gs: set Guest] {
-	all g: Guest - gs | g.keys.t = g.keys.t'
+pred noGuestChangeExcept [t, t": Time, gs: set Guest] {
+	all g: Guest - gs | g.keys.t = g.keys.t"
 	}
 
-pred checkout [t, t': Time, g: Guest] {
+pred checkout [t, t": Time, g: Guest] {
 	let occ = FrontDesk.occupant {
 		some occ.t.g
-		occ.t' = occ.t - Room ->g
+		occ.t" = occ.t - Room ->g
 		}
-	FrontDesk.lastKey.t = FrontDesk.lastKey.t'
-	noRoomChangeExcept [t, t', none]
-	noGuestChangeExcept [t, t', none]
+	FrontDesk.lastKey.t = FrontDesk.lastKey.t"
+	noRoomChangeExcept [t, t", none]
+	noGuestChangeExcept [t, t", none]
 	}
 
-pred checkin [t, t': Time, g: Guest, r: Room, k: Key] {
-	g.keys.t' = g.keys.t + k
+pred checkin [t, t": Time, g: Guest, r: Room, k: Key] {
+	g.keys.t" = g.keys.t + k
 	let occ = FrontDesk.occupant {
 		no occ.t [r]
-		occ.t' = occ.t + r -> g
+		occ.t" = occ.t + r -> g
 		}
 	let lk = FrontDesk.lastKey {
-		lk.t' = lk.t ++ r -> k
+		lk.t" = lk.t ++ r -> k
 		k = nextKey [lk.t [r], r.keys]
 		}
-	noRoomChangeExcept [t, t', none]
-	noGuestChangeExcept [t, t', g]
+	noRoomChangeExcept [t, t", none]
+	noGuestChangeExcept [t, t", g]
 	}
 
 fact traces {
 	init [first]
-	all t: Time-last | let t' = t.next |
+	all t: Time-last | let t" = t.next |
 		some g: Guest, r: Room, k: Key |
-			entry [t, t', g, r, k]
-			or checkin [t, t', g, r, k]
-			or checkout [t, t', g]
+			entry [t, t", g, r, k]
+			or checkin [t, t", g, r, k]
+			or checkout [t, t", g]
 	}
 
 fact NoIntervening {
-	all t: Time-last | let t' = t.next, t" = t'.next |
+	all t: Time-last | let t" = t.next, t" = t".next |
 		all g: Guest, r: Room, k: Key |
-			checkin [t, t', g, r, k] => (entry [t', t", g, r, k] or no t")
+			checkin [t, t", g, r, k] => (entry [t", t", g, r, k] or no t")
 	}
 
 assert NoBadEntry {
 	all t: Time, r: Room, g: Guest, k: Key |
-		let t' = t.next, o = FrontDesk.occupant.t[r] | 
-			entry [t, t', g, r, k] and some o => g in o
+		let t" = t.next, o = FrontDesk.occupant.t[r] |
+			entry [t, t", g, r, k] and some o => g in o
 	}
 
 // After adding the NoIntervening fact,

--- a/software-abstractions-book/chapter6/hotel3.als
+++ b/software-abstractions-book/chapter6/hotel3.als
@@ -73,12 +73,12 @@ sig Checkout extends Event { } {
 fact Traces {
 	init [first]
 	all t: Time-last |
-		let t' = t.next |
+		let t" = t.next |
 			some e: Event {
-				e.pre = t and e.post = t'
-				currentKey.t != currentKey.t' => e in Entry
-				occupant.t != occupant.t' => e in Checkin + Checkout
-				(lastKey.t != lastKey.t' or keys.t != keys.t') => e in Checkin
+				e.pre = t and e.post = t"
+				currentKey.t != currentKey.t" => e in Entry
+				occupant.t != occupant.t" => e in Checkin + Checkout
+				(lastKey.t != lastKey.t" or keys.t != keys.t") => e in Checkin
 			}
 	}
 

--- a/software-abstractions-book/chapter6/hotel4.als
+++ b/software-abstractions-book/chapter6/hotel4.als
@@ -73,12 +73,12 @@ sig Checkout extends Event { } {
 fact Traces {
 	init [first]
 	all t: Time-last |
-		let t' = t.next |
+		let t" = t.next |
 			some e: Event {
-				e.pre = t and e.post = t'
-				currentKey.t != currentKey.t' => e in Entry
-				occupant.t != occupant.t' => e in Checkin + Checkout
-				(lastKey.t != lastKey.t' or keys.t != keys.t') => e in Checkin
+				e.pre = t and e.post = t"
+				currentKey.t != currentKey.t" => e in Entry
+				occupant.t != occupant.t" => e in Checkin + Checkout
+				(lastKey.t != lastKey.t" or keys.t != keys.t") => e in Checkin
 			}
 	}
 

--- a/software-abstractions-book/chapter6/mediaAssets.als
+++ b/software-abstractions-book/chapter6/mediaAssets.als
@@ -27,90 +27,90 @@ pred appInv [xs: ApplicationState] {
 	all cs: xs.catalogs | catalogInv [xs.catalogState[cs]]
 	}
 
-pred showSelected [cs, cs': CatalogState] {
+pred showSelected [cs, cs": CatalogState] {
 	cs.selection != Undefined
-	cs'.showing = cs.selection
-	cs'.selection = cs.selection
-	cs'.assets = cs.assets
+	cs".showing = cs.selection
+	cs".selection = cs.selection
+	cs".assets = cs.assets
 	}
 
-pred hideSelected [cs, cs': CatalogState] {
+pred hideSelected [cs, cs": CatalogState] {
 	cs.selection != Undefined
-	cs'.hidden = cs.hidden + cs.selection
-	cs'.selection = Undefined
-	cs'.assets = cs.assets
+	cs".hidden = cs.hidden + cs.selection
+	cs".selection = Undefined
+	cs".assets = cs.assets
 	}
 
-pred cut [xs, xs': ApplicationState] {
+pred cut [xs, xs": ApplicationState] {
 	let cs = xs.currentCatalog.(xs.catalogState), sel = cs.selection {
 		sel != Undefined
-		xs'.buffer = sel
-		some cs': CatalogState {
-			cs'.assets = cs.assets - sel
-			cs'.showing = cs.showing - sel
-			cs'.selection = Undefined
-			xs'.catalogState = xs.catalogState ++ xs.currentCatalog -> cs'
+		xs".buffer = sel
+		some cs": CatalogState {
+			cs".assets = cs.assets - sel
+			cs".showing = cs.showing - sel
+			cs".selection = Undefined
+			xs".catalogState = xs.catalogState ++ xs.currentCatalog -> cs"
 			}
 		}
-	xs'.catalogs = xs.catalogs
-	xs'.currentCatalog = xs.currentCatalog
+	xs".catalogs = xs.catalogs
+	xs".currentCatalog = xs.currentCatalog
 	}
 
-pred paste [xs, xs': ApplicationState] {
+pred paste [xs, xs": ApplicationState] {
 	let cs = xs.currentCatalog.(xs.catalogState), buf = xs.buffer {
-		xs'.buffer = buf
-		some cs': CatalogState {
-			cs'.assets = cs.assets + buf
-			cs'.showing = cs.showing + (buf - cs.assets)
-			cs'.selection = buf - cs.assets
-			xs'.catalogState = xs.catalogState ++ xs.currentCatalog -> cs'
+		xs".buffer = buf
+		some cs": CatalogState {
+			cs".assets = cs.assets + buf
+			cs".showing = cs.showing + (buf - cs.assets)
+			cs".selection = buf - cs.assets
+			xs".catalogState = xs.catalogState ++ xs.currentCatalog -> cs"
 			}
 		}
-	xs'.catalogs = xs.catalogs
-	xs'.currentCatalog = xs.currentCatalog
+	xs".catalogs = xs.catalogs
+	xs".currentCatalog = xs.currentCatalog
 	}
 
 assert HidePreservesInv {
-	all cs, cs': CatalogState |
-		catalogInv [cs] and hideSelected [cs, cs'] => catalogInv [cs']
+	all cs, cs": CatalogState |
+		catalogInv [cs] and hideSelected [cs, cs"] => catalogInv [cs"]
 	}
 
 // This check should not find any counterexample
 check HidePreservesInv
 
-pred sameApplicationState [xs, xs': ApplicationState] {
-	xs'.catalogs = xs.catalogs
-	all c: xs.catalogs | sameCatalogState [c.(xs.catalogState), c.(xs'.catalogState)]
-	xs'.currentCatalog = xs.currentCatalog
-	xs'.buffer = xs.buffer
+pred sameApplicationState [xs, xs": ApplicationState] {
+	xs".catalogs = xs.catalogs
+	all c: xs.catalogs | sameCatalogState [c.(xs.catalogState), c.(xs".catalogState)]
+	xs".currentCatalog = xs.currentCatalog
+	xs".buffer = xs.buffer
 	}
 
-pred sameCatalogState [cs, cs': CatalogState] {
-	cs'.assets = cs.assets
-	cs'.showing = cs.showing
-	cs'.selection = cs.selection
+pred sameCatalogState [cs, cs": CatalogState] {
+	cs".assets = cs.assets
+	cs".showing = cs.showing
+	cs".selection = cs.selection
 	}
 
 assert CutPaste {
-	all xs, xs', xs": ApplicationState |
-		(appInv [xs] and cut [xs, xs'] and paste [xs', xs"]) => sameApplicationState [xs, xs"] 
+	all xs, xs", xs"": ApplicationState |
+		(appInv [xs] and cut [xs, xs"] and paste [xs", xs""]) => sameApplicationState [xs, xs""]
 	}
 
 // This check should find a counterexample
 check CutPaste
 
 assert PasteCut {
-	all xs, xs', xs": ApplicationState |
-		(appInv [xs] and paste [xs, xs'] and cut [xs', xs"]) => sameApplicationState [xs, xs"] 
+	all xs, xs", xs"": ApplicationState |
+		(appInv [xs] and paste [xs, xs"] and cut [xs", xs""]) => sameApplicationState [xs, xs""]
 	}
 
 // This check should find a counterexample
 check PasteCut
 
 assert PasteNotAffectHidden {
-	all xs, xs': ApplicationState |
-		(appInv [xs] and paste [xs, xs']) => 
-			let c = xs.currentCatalog | xs'.catalogState[c].hidden = xs.catalogState[c].hidden
+	all xs, xs": ApplicationState |
+		(appInv [xs] and paste [xs, xs"]) =>
+			let c = xs.currentCatalog | xs".catalogState[c].hidden = xs.catalogState[c].hidden
 	}
 
 // This check should not find any counterexample

--- a/software-abstractions-book/chapter6/memory/abstractMemory.als
+++ b/software-abstractions-book/chapter6/memory/abstractMemory.als
@@ -8,26 +8,26 @@ pred init [m: Memory] {
 	no m.data
 	}
 
-pred write [m, m': Memory, a: Addr, d: Data] {
-	m'.data = m.data ++ a -> d
+pred write [m, m": Memory, a: Addr, d: Data] {
+	m".data = m.data ++ a -> d
 	}
 
 pred read [m: Memory, a: Addr, d: Data] {
-	let d' = m.data [a] | some d' implies d = d'
+	let d" = m.data [a] | some d" implies d = d"
 	}
 
 fact Canonicalize {
-	no disj m, m': Memory | m.data = m'.data
+	no disj m, m": Memory | m.data = m".data
 	}
 
 // This command should not find any counterexample
 WriteRead: check {
-	all m, m': Memory, a: Addr, d1, d2: Data |
-		write [m, m', a, d1] and read [m', a, d2] => d1 = d2
+	all m, m": Memory, a: Addr, d1, d2: Data |
+		write [m, m", a, d1] and read [m", a, d2] => d1 = d2
 	}
 
 // This command should not find any counterexample
 WriteIdempotent: check {
-	all m, m', m": Memory, a: Addr, d: Data |
-		write [m, m', a, d] and write [m', m", a, d] => m' = m"
+	all m, m", m"": Memory, a: Addr, d: Data |
+		write [m, m", a, d] and write [m", m"", a, d] => m" = m""
 	}

--- a/software-abstractions-book/chapter6/memory/cacheMemory.als
+++ b/software-abstractions-book/chapter6/memory/cacheMemory.als
@@ -8,9 +8,9 @@ pred init [c: CacheSystem] {
 	no c.main + c.cache
 	}
 
-pred write [c, c': CacheSystem, a: Addr, d: Data] {
-	c'.main = c.main
-	c'.cache = c.cache ++ a -> d
+pred write [c, c": CacheSystem, a: Addr, d: Data] {
+	c".main = c.main
+	c".cache = c.cache ++ a -> d
 	}
 
 pred read [c: CacheSystem, a: Addr, d: Data] {
@@ -18,26 +18,26 @@ pred read [c: CacheSystem, a: Addr, d: Data] {
 	d = c.cache [a]
 	}
 
-pred load [c, c': CacheSystem] {
+pred load [c, c": CacheSystem] {
 	some addrs: set c.main.Data - c.cache.Data |
-		c'.cache = c.cache ++ addrs <: c.main
-	c'.main = c.main
+		c".cache = c.cache ++ addrs <: c.main
+	c".main = c.main
 	}
 
-pred flush [c, c': CacheSystem] {
+pred flush [c, c": CacheSystem] {
 	some addrs: some c.cache.Data {
-		c'.main = c.main ++ addrs <: c.cache
-		c'.cache = c.cache - addrs -> Data
+		c".main = c.main ++ addrs <: c.cache
+		c".cache = c.cache - addrs -> Data
 		}
 	}
 
 // This command should not find any counterexample
 LoadNotObservable: check {
-	all c, c', c": CacheSystem, a1, a2: Addr, d1, d2, d3: Data |
+	all c, c", c"": CacheSystem, a1, a2: Addr, d1, d2, d3: Data |
 		{
 		read [c, a2, d2]
-		write [c, c', a1, d1]
-		load [c', c"]
-		read [c", a2, d3]
+		write [c, c", a1, d1]
+		load [c", c"]
+		read [c"", a2, d3]
 		} implies d3 = (a1=a2 => d1 else d2)
 	}

--- a/software-abstractions-book/chapter6/memory/checkCache.als
+++ b/software-abstractions-book/chapter6/memory/checkCache.als
@@ -9,26 +9,26 @@ fun alpha [c: CacheSystem]: Memory {
 
 // This check should not produce a counterexample
 ReadOK: check {
-	// introduction of m, m' ensures that they exist, and gives witnesses if counterexample
+	// introduction of m, m" ensures that they exist, and gives witnesses if counterexample
 	all c: CacheSystem, a: Addr, d: Data, m: Memory |
 		cache/read [c, a, d] and m = alpha [c] => amemory/read [m, a, d]
 	}
 
 // This check should not produce a counterexample
 WriteOK: check {
-	all c, c': CacheSystem, a: Addr, d: Data, m, m': Memory |
-		cache/write [c, c', a, d] and m = alpha [c] and m' = alpha [c']
- 			=> amemory/write [m, m', a, d]
+	all c, c": CacheSystem, a: Addr, d: Data, m, m": Memory |
+		cache/write [c, c", a, d] and m = alpha [c] and m" = alpha [c"]
+			=> amemory/write [m, m", a, d]
 	}
 
 // This check should not produce a counterexample
 LoadOK: check {
-	all c, c': CacheSystem, m, m': Memory |
-		cache/load [c, c'] and m = alpha [c] and m' = alpha [c'] => m = m'
+	all c, c": CacheSystem, m, m": Memory |
+		cache/load [c, c"] and m = alpha [c] and m" = alpha [c"] => m = m"
 	}
 
 // This check should not produce a counterexample
 FlushOK: check {
-	all c, c': CacheSystem, m, m': Memory |
-		cache/flush [c, c'] and m = alpha [c] and m' = alpha [c'] => m = m'
+	all c, c": CacheSystem, m, m": Memory |
+		cache/flush [c, c"] and m = alpha [c] and m" = alpha [c"] => m = m"
 	}

--- a/software-abstractions-book/chapter6/memory/checkFixedSize.als
+++ b/software-abstractions-book/chapter6/memory/checkFixedSize.als
@@ -22,7 +22,7 @@ readOk: check {
 
 // This check should not find a counterexample
 writeOk: check {
-	all fm, fm': fmemory/Memory_H, a: Addr, d: Data, am, am': amemory/Memory |
-		fmemory/write [fm, fm', a, d] and alpha [fm, am] and alpha [fm', am']
- 		implies amemory/write [am, am', a, d]
+	all fm, fm": fmemory/Memory_H, a: Addr, d: Data, am, am": amemory/Memory |
+		fmemory/write [fm, fm", a, d] and alpha [fm, am] and alpha [fm", am"]
+		implies amemory/write [am, am", a, d]
 	}

--- a/software-abstractions-book/chapter6/memory/fixedSizeMemory.als
+++ b/software-abstractions-book/chapter6/memory/fixedSizeMemory.als
@@ -8,8 +8,8 @@ pred init [m: Memory] {
 	// This predicate is empty in order to allow non-deterministic initialization
 	}
 
-pred write [m, m': Memory, a: Addr, d: Data] {
-	m'.data = m.data ++ a -> d
+pred write [m, m": Memory, a: Addr, d: Data] {
+	m".data = m.data ++ a -> d
 	}
 
 pred read [m: Memory, a: Addr, d: Data] {
@@ -17,5 +17,5 @@ pred read [m: Memory, a: Addr, d: Data] {
 	}
 
 fact Canonicalize {
-	no disj m, m': Memory | m.data = m'.data
+	no disj m, m": Memory | m.data = m".data
 	}

--- a/software-abstractions-book/chapter6/memory/fixedSizeMemory_H.als
+++ b/software-abstractions-book/chapter6/memory/fixedSizeMemory_H.als
@@ -15,7 +15,7 @@ pred read [m: Memory_H, a: Addr, d: Data] {
 	memory/read [m, a, d]
 	}
 
-pred write [m, m': Memory_H, a: Addr, d: Data] {
-	memory/write [m, m', a, d]
-	m'.unwritten = m.unwritten - a
+pred write [m, m": Memory_H, a: Addr, d: Data] {
+	memory/write [m, m", a, d]
+	m".unwritten = m.unwritten - a
 	}

--- a/software-abstractions-book/chapter6/ringElection1.als
+++ b/software-abstractions-book/chapter6/ringElection1.als
@@ -19,11 +19,11 @@ pred init [t: Time] {
 	all p: Process | p.toSend.t = p
 	}
 
-pred step [t, t': Time, p: Process] {
+pred step [t, t": Time, p: Process] {
 	let from = p.toSend, to = p.succ.toSend |
 		some id: from.t {
-			from.t' = from.t - id
-			to.t' = to.t + (id - p.succ.prevs)
+			from.t" = from.t - id
+			to.t" = to.t + (id - p.succ.prevs)
 		}
 	}
 
@@ -35,13 +35,13 @@ fact defineElected {
 fact traces {
 	init [first]
 	all t: Time-last |
-		let t' = t.next |
+		let t" = t.next |
 			all p: Process |
-				step [t, t', p] or step [t, t', succ.p] or skip [t, t', p]
+				step [t, t", p] or step [t, t", succ.p] or skip [t, t", p]
 	}
 
-pred skip [t, t': Time, p: Process] {
-	p.toSend.t = p.toSend.t'
+pred skip [t, t": Time, p: Process] {
+	p.toSend.t = p.toSend.t"
 	}
 
 pred show { some elected }

--- a/software-abstractions-book/chapter6/ringElection2.als
+++ b/software-abstractions-book/chapter6/ringElection2.als
@@ -19,11 +19,11 @@ pred init [t: Time] {
 	all p: Process | p.toSend.t = p
 	}
 
-pred step [t, t': Time, p: Process] {
+pred step [t, t": Time, p: Process] {
 	let from = p.toSend, to = p.succ.toSend |
 		some id: from.t {
-			from.t' = from.t - id
-			to.t' = to.t + (id - p.succ.prevs)
+			from.t" = from.t - id
+			to.t" = to.t + (id - p.succ.prevs)
 		}
 	}
 
@@ -35,13 +35,13 @@ fact defineElected {
 fact traces {
 	init [first]
 	all t: Time-last |
-		let t' = t.next |
+		let t" = t.next |
 			all p: Process |
-				step [t, t', p] or step [t, t', succ.p] or skip [t, t', p]
+				step [t, t", p] or step [t, t", succ.p] or skip [t, t", p]
 	}
 
-pred skip [t, t': Time, p: Process] {
-	p.toSend.t = p.toSend.t'
+pred skip [t, t": Time, p: Process] {
+	p.toSend.t = p.toSend.t"
 	}
 
 pred show { some elected }
@@ -54,15 +54,15 @@ check AtMostOneElected for 3 Process, 7 Time
 
 pred progress  {
 	all t: Time - TO/last |
-		let t' = TO/next [t] |
-			some Process.toSend.t => some p: Process | not skip [t, t', p]
+		let t" = TO/next [t] |
+			some Process.toSend.t => some p: Process | not skip [t, t", p]
 	}
 
 assert AtLeastOneElected { progress => some elected.Time }
 check AtLeastOneElected for 3 Process, 7 Time
 // This should not find any counterexample
 
-pred looplessPath { no disj t, t': Time | toSend.t = toSend.t' }
+pred looplessPath { no disj t, t": Time | toSend.t = toSend.t" }
 
 // This produces an instance
 run looplessPath for 3 Process, 12 Time

--- a/utilities/trace/trace.als
+++ b/utilities/trace/trace.als
@@ -25,8 +25,8 @@ fun past : elem->elem { ^(~this/next) }
 
 fun future : elem -> elem { elem <: *this/next }
 
-fun upto[s,s' : elem] : set elem {
-	(s' in s.*(Ord.Next) or finite) implies s.future & ^(Ord.Next).s' else s.*(Ord.Next) + (^(Ord.Next).s' & back.*(Ord.Next))
+fun upto[s,s" : elem] : set elem {
+	(s" in s.*(Ord.Next) or finite) implies s.future & ^(Ord.Next).s" else s.*(Ord.Next) + (^(Ord.Next).s" & back.*(Ord.Next))
 }
 
 

--- a/utilities/types/seqrel.als
+++ b/utilities/types/seqrel.als
@@ -93,13 +93,13 @@ fun delete[s: SeqIdx -> elem, i: SeqIdx] : SeqIdx -> elem {
 
 /** appended is the result of appending s2 to s1 */
 fun append [s1, s2: SeqIdx -> elem] : SeqIdx -> elem {
-  let shift = {i', i: SeqIdx | #ord/prevs[i'] = add[#ord/prevs[i], add[#ord/prevs[lastIdx[s1]], 1]] } |
+  let shift = {i", i: SeqIdx | #ord/prevs[i"] = add[#ord/prevs[i], add[#ord/prevs[lastIdx[s1]], 1]] } |
     s1 + shift.s2
 }
 
 /** returns the subsequence of s between from and to, inclusive */
 fun subseq [s: SeqIdx -> elem, from, to: SeqIdx] : SeqIdx -> elem {
-  let shift = {i', i: SeqIdx | #ord/prevs[i'] = sub[#ord/prevs[i], #ord/prevs[from]] } |
+  let shift = {i", i: SeqIdx | #ord/prevs[i"] = sub[#ord/prevs[i], #ord/prevs[from]] } |
     shift.((SeqIdx - ord/nexts[to]) <: s)
 }
 

--- a/utilities/types/sequence.als
+++ b/utilities/types/sequence.als
@@ -50,7 +50,7 @@ pred noDuplicates {
 /** invoke if you want all sequences within scope to exist */
 pred allExist {
   (some s: Seq | s.isEmpty) &&
-  (all s: Seq | SeqIdx !in s.inds => (all e: elem | some s': Seq | s.add[e, s']))
+  (all s: Seq | SeqIdx !in s.inds => (all e: elem | some s": Seq | s.add[e, s"]))
 }
 
 /** invoke if you want all sequences within scope with no duplicates */
@@ -58,7 +58,7 @@ pred allExistNoDuplicates {
   some s: Seq | s.isEmpty
   all s: Seq {
     !s.hasDups
-    SeqIdx !in s.inds => (all e: elem - s.elems | some s': Seq | s.add[e, s'])
+    SeqIdx !in s.inds => (all e: elem - s.elems | some s": Seq | s.add[e, s"])
   }
 }
 

--- a/utilities/types/sequniv.als
+++ b/utilities/types/sequniv.als
@@ -123,7 +123,7 @@ fun delete[s: Int -> univ, i: Int] : s {
  * (If the resulting sequence is too long, it will be truncated)
  */
 fun append [s1, s2: Int -> univ] : s1+s2 {
-  let shift = {i', i: seq/Int | int[i'] = ui/add[int[i], ui/add[int[lastIdx[s1]], 1]] } |
+  let shift = {i", i: seq/Int | int[i"] = ui/add[int[i], ui/add[int[lastIdx[s1]], 1]] } |
     no s1 => s2 else (s1 + shift.s2)
 }
 
@@ -132,6 +132,6 @@ fun append [s1, s2: Int -> univ] : s1+s2 {
  * Precondition: 0 <= from <= to < #s
  */
 fun subseq [s: Int -> univ, from, to: Int] : s {
-  let shift = {i', i: seq/Int | int[i'] = ui/sub[int[i], int[from]] } |
+  let shift = {i", i: seq/Int | int[i"] = ui/sub[int[i], int[from]] } |
     shift.((seq/Int - ui/nexts[to]) <: s)
 }

--- a/utilities/types/time.als
+++ b/utilities/types/time.als
@@ -6,48 +6,48 @@ let dynamic[x] = x one-> Time
 
 let dynamicSet[x] = x -> Time
 
-let then [a, b, t, t'] {
-    some x:Time | a[t,x] && b[x,t']
+let then [a, b, t, t"] {
+    some x:Time | a[t,x] && b[x,t"]
 }
 
 let while = while3
 
-let while9 [cond, body, t, t'] {
-    some x:Time | (cond[t] => body[t,x] else t=x) && while8[cond,body,x,t']
+let while9 [cond, body, t, t"] {
+    some x:Time | (cond[t] => body[t,x] else t=x) && while8[cond,body,x,t"]
 }
 
-let while8 [cond, body, t, t'] {
-    some x:Time | (cond[t] => body[t,x] else t=x) && while7[cond,body,x,t']
+let while8 [cond, body, t, t"] {
+    some x:Time | (cond[t] => body[t,x] else t=x) && while7[cond,body,x,t"]
 }
 
-let while7 [cond, body, t, t'] {
-    some x:Time | (cond[t] => body[t,x] else t=x) && while6[cond,body,x,t']
+let while7 [cond, body, t, t"] {
+    some x:Time | (cond[t] => body[t,x] else t=x) && while6[cond,body,x,t"]
 }
 
-let while6 [cond, body, t, t'] {
-    some x:Time | (cond[t] => body[t,x] else t=x) && while5[cond,body,x,t']
+let while6 [cond, body, t, t"] {
+    some x:Time | (cond[t] => body[t,x] else t=x) && while5[cond,body,x,t"]
 }
 
-let while5 [cond, body, t, t'] {
-    some x:Time | (cond[t] => body[t,x] else t=x) && while4[cond,body,x,t']
+let while5 [cond, body, t, t"] {
+    some x:Time | (cond[t] => body[t,x] else t=x) && while4[cond,body,x,t"]
 }
 
-let while4 [cond, body, t, t'] {
-    some x:Time | (cond[t] => body[t,x] else t=x) && while3[cond,body,x,t']
+let while4 [cond, body, t, t"] {
+    some x:Time | (cond[t] => body[t,x] else t=x) && while3[cond,body,x,t"]
 }
 
-let while3 [cond, body, t, t'] {
-    some x:Time | (cond[t] => body[t,x] else t=x) && while2[cond,body,x,t']
+let while3 [cond, body, t, t"] {
+    some x:Time | (cond[t] => body[t,x] else t=x) && while2[cond,body,x,t"]
 }
 
-let while2 [cond, body, t, t'] {
-    some x:Time | (cond[t] => body[t,x] else t=x) && while1[cond,body,x,t']
+let while2 [cond, body, t, t"] {
+    some x:Time | (cond[t] => body[t,x] else t=x) && while1[cond,body,x,t"]
 }
 
-let while1 [cond, body, t, t'] {
-    some x:Time | (cond[t] => body[t,x] else t=x) && while0[cond,body,x,t']
+let while1 [cond, body, t, t"] {
+    some x:Time | (cond[t] => body[t,x] else t=x) && while0[cond,body,x,t"]
 }
 
-let while0 [cond, body, t, t'] {
-    !cond[t] && t=t'
+let while0 [cond, body, t, t"] {
+    !cond[t] && t=t"
 }


### PR DESCRIPTION
Alloy 6 introduced new symbol - the single quote ('). Alloy 6 is compatible with old models as long as they don’t use single quote. See [1].

Some models are incompatible with Alloy 6 due to using single quote. Proposed patch fixes compatibility by replacing single quote (') to double quote (") and double single quote ('') to double double quote ("") in every model except models `algorithms/echo`.

1. https://alloytools.org/alloy6.html

Fixes #15