### PR TITLE
Fix hotel2.als in wrong update for Alloy 6

### DIFF
--- a/software-abstractions-book/chapter6/hotel2.als
+++ b/software-abstractions-book/chapter6/hotel2.als
@@ -92,9 +92,9 @@ fact traces {
 	}
 
 fact NoIntervening {
-	all t: Time-last | let t" = t.next, t" = t".next |
+	all t: Time-last | let t" = t.next, t"" = t".next |
 		all g: Guest, r: Room, k: Key |
-			checkin [t, t", g, r, k] => (entry [t", t", g, r, k] or no t")
+			checkin [t, t", g, r, k] => (entry [t", t"", g, r, k] or no t"")
 	}
 
 assert NoBadEntry {


### PR DESCRIPTION
t' was changed to t" but t" was not changed to t"" in the previous update.